### PR TITLE
chore: configurable ts path for benchmarks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,16 @@
 {
   "npm.packageManager": "pnpm",
-  "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "cSpell.words": [
+    "antfu",
+    "Trpc",
+    "tsperf"
+  ],
+  "eslint.experimental.useFlatConfig": true,
+  "eslint.format.enable": true,
+  "eslint.lintTask.enable": false,
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "typescript.tsdk": "/home/hw/.vscode-server/data/User/globalStorage/typeholes.ts-versions-switcher/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -30,15 +30,77 @@
     "onLanguage:typescript",
     "workspaceContains:tsconfig.json"
   ],
+  "contributes": {
+    "configuration": {
+      "title": "tsperf.tracer",
+      "properties": {
+        "tsperf.tracer.typescript-path-mode": {
+          "type": "string",
+          "default": "vscode-builtin",
+          "description": "Use TypeScript from",
+          "enum": [
+            "vscode-builtin",
+            "tsdk",
+            "workspace",
+            "explicit"
+          ],
+          "enumDescriptions": [
+            "VsCode's built in TypeScript",
+            "VsCode TSDK setting",
+            "node_modules in you project",
+            "Use tracer TypeScript path setting"
+          ]
+        },
+        "tsperf.tracer.typescript-path": {
+          "type": "string",
+          "default": "",
+          "description": "Path to TypeScript. Must be specified if 'Use TypeScript from' is 'Use tracer TypeScript path setting'"
+        }
+      }
+    },
+    "commandPalette": [
+      {
+        "command": "tsperf.tracer.sendTrace",
+        "when": "!notebookEditorFocused && editorLangId == 'json'"
+      }
+    ],
+    "commands": [
+      {
+        "command": "tsperf.tracer.gotoTracePosition",
+        "title": "Goto position in trace"
+      },
+      {
+        "command": "tsperf.tracer.openInBrowser",
+        "title": "Open trace view in browser",
+        "icon": {
+          "dark": "resources/todo.svg",
+          "light": "resources/todo.svg"
+        }
+      },
+      {
+        "command": "tsperf.tracer.runTrace",
+        "title": "tsc trace",
+        "icon": {
+          "dark": "resources/todo.svg",
+          "light": "resources/todo.svg"
+        }
+      },
+      {
+        "command": "tsperf.tracer.sendTrace",
+        "title": "Send Trace to Trace Viewer",
+        "when": "!notebookEditorFocused && editorLangId == 'json'"
+      }
+    ]
+  },
   "scripts": {
     "build": "rollup -c",
-    "dev": "nr build --watch",
+    "dev": "nr build --watch --sourcemap",
     "lint": "eslint .",
     "vscode:prepublish": "nr build",
     "publish": "vsce publish --no-dependencies",
     "package": "vsce package --no-dependencies",
     "test": "vitest",
-    "typecheck": "tsc --noEmit && pnpm --filter ui typecheck",
+    "typecheck": "tsc --noEmit ",
     "release": "bumpp && nr publish"
   },
   "devDependencies": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,64 @@
+import * as vscode from 'vscode'
+import { setTsPath } from './tsUtil'
+
+const configKeys = [
+  'typescript-path',
+  'typescript-path-mode',
+] as const
+
+type ConfigKey = typeof configKeys[number]
+const configKey = 'tsperf.tracer'
+
+const currentConfig = {
+  'typescript-path': '',
+  'typescript-path-mode': 'vscode-builtin',
+} satisfies Record<ConfigKey, any>
+
+function isString(x: unknown): x is string {
+  return typeof x === 'string'
+}
+const configValidate = {
+  'typescript-path': isString,
+  'typescript-path-mode': isString,
+} satisfies Record<ConfigKey, any>
+
+const configHandlers = {
+  'typescript-path': (_value: string) => { currentConfig['typescript-path-mode'] = '!ForceUpdate' },
+  'typescript-path-mode': (value: string) => { setTsPath(value, currentConfig['typescript-path']) },
+} satisfies Record<ConfigKey, any>
+
+let configuration = vscode.workspace.getConfiguration(configKey)
+
+const afterConfigHandlers: [keys: ConfigKey[], handler: (config: typeof currentConfig) => void][] = []
+
+export function updateConfig() {
+  const changedKeys: ConfigKey[] = []
+  for (const key of configKeys) {
+    const newValue = configuration.get(key)
+    if (newValue && newValue !== currentConfig[key]) {
+      changedKeys.push(key)
+      if (!configValidate[key](newValue)) {
+        vscode.window.showErrorMessage(`wrong type received for configuration item ${key}: ${newValue}`)
+        break
+      }
+      currentConfig[key] = newValue
+      configHandlers[key](newValue)
+    }
+  }
+  for (const after of afterConfigHandlers) {
+    const [keys, handler] = after
+    if (keys.some(key => changedKeys.includes(key)))
+      handler(currentConfig)
+  }
+}
+
+vscode.workspace.onDidChangeConfiguration((change) => {
+  if (change.affectsConfiguration(configKey)) {
+    configuration = vscode.workspace.getConfiguration(configKey)
+    updateConfig()
+  }
+})
+
+export function afterConfigUpdate(keys: ConfigKey[], handler: (config: typeof currentConfig) => void) {
+  afterConfigHandlers.push([keys, handler])
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,17 +8,26 @@ import * as vscode from 'vscode'
 
 import { log } from './logger'
 import { getParsedCommandLine, getTsconfigFile } from './shared'
+import { afterConfigUpdate, updateConfig } from './configuration'
+import { getTsPath } from './tsUtil'
 
 let ts: typeof import('typescript')
 let tsPath: string
 
-export async function activate(context: vscode.ExtensionContext) {
-  log('============extension activated============')
-
-  tsPath = path.join(path.dirname(vscode.extensions.getExtension('vscode.typescript-language-features')!.extensionPath), 'node_modules/typescript')
+function getTs() {
+  tsPath = getTsPath()
 
   // eslint-disable-next-line ts/no-require-imports
   ts = require(tsPath)
+}
+export async function activate(context: vscode.ExtensionContext) {
+  log('============extension activated============')
+
+  updateConfig()
+
+  getTs()
+
+  afterConfigUpdate(['typescript-path', 'typescript-path-mode'], getTs)
 
   const collection = vscode.languages.createDiagnosticCollection('tsperf')
 

--- a/src/tsUtil.ts
+++ b/src/tsUtil.ts
@@ -1,0 +1,47 @@
+import path from 'node:path'
+import * as vscode from 'vscode'
+
+let ts: typeof import('typescript')
+let tsPath: string
+
+export function getTs() {
+  if (!ts)
+    throw new Error('ts not initialized')
+
+  return ts
+}
+
+export function getTsPath() {
+  if (!tsPath)
+    throw new Error('tsPath no initialized')
+
+  return tsPath
+}
+
+export function setTsPath(mode: string, explicitPath: string) {
+  switch (mode) {
+    case 'explicit':
+      tsPath = explicitPath
+      break
+    case 'vscode-builtin':
+      tsPath = path.join(path.dirname(vscode.extensions.getExtension('vscode.typescript-language-features')!.extensionPath), 'node_modules/typescript')
+      break
+    case 'tsdk':
+      tsPath = (vscode.workspace.getConfiguration('typescript').get<string>('tsdk') ?? '').replace(/\/lib$/, '')
+      break
+    case 'workspace':
+      tsPath = getWorkspaceTsPath()
+      break
+  }
+  // eslint-disable-next-line no-console
+  console.log(tsPath)
+  return tsPath
+}
+
+function getWorkspaceTsPath() {
+  const folder = vscode.workspace.workspaceFolders?.[0]
+  if (!folder)
+    return ''
+
+  return path.join(folder.uri.fsPath, 'node_modules', 'typescript')
+}


### PR DESCRIPTION
Users need to be able to choose a location for ts for projects that do not build with vscode's built in versoin