### PR TITLE
chore: move `debug.sh` into launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,8 @@
       "runtimeExecutable": "${execPath}",
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}",
-        "${workspaceFolder}/playground"
+        "${workspaceFolder}/playground",
+        "--inspect-extensions 3300",
       ],
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "generate:contributes": "jiti ./scripts/generate-contributes.ts",
     "pretest": "nr build && nr lint",
     "build": "nr generate:contributes && nr ui:build && rollup -c",
-    "dev": "nr build --watch --sourcemap",
+    "dev": "nr typecheck && nr ui:build --sourcemap && nr build --sourcemap && rollup -c --watch --sourcemap",
     "ui:dev": "nuxt dev ui",
     "ui:build": "nuxt build ui",
     "lint": "eslint .",

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -1,4 +1,0 @@
-pnpm typecheck &&
-pnpm ui:build --sourcemap &&
-pnpm build --sourcemap &&
-code ./playground --extensionDevelopmentPath=.  --inspect-extensions 3300


### PR DESCRIPTION
does this work as well for you, when using the 'Debug: Start debugging' command in vscode?