### PR TITLE
Add trace line visual tones

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/-1
-          cache: pnpm
 
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile
@@ -42,7 +41,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/-1
-          cache: pnpm
 
       - run: npx changelogithub
         env:

--- a/src/traceTone.ts
+++ b/src/traceTone.ts
@@ -1,0 +1,40 @@
+import type { Tree } from './traceTree'
+
+export type TraceLineTone = 'default' | 'slow' | 'type-heavy' | 'mixed'
+
+const SLOW_TRACE_US = 50_000
+const TYPE_HEAVY_COUNT = 100
+
+export function getTraceLineTone(tree: Pick<Tree, 'line' | 'typeCnt' | 'childTypeCnt'>): TraceLineTone {
+  const duration = tree.line.dur ?? 0
+  const totalTypes = tree.typeCnt + tree.childTypeCnt
+  const isSlow = duration >= SLOW_TRACE_US
+  const isTypeHeavy = totalTypes >= TYPE_HEAVY_COUNT
+
+  if (isSlow && isTypeHeavy)
+    return 'mixed'
+  if (isSlow)
+    return 'slow'
+  if (isTypeHeavy)
+    return 'type-heavy'
+  return 'default'
+}
+
+export function getTraceLineToneStyle(tone: TraceLineTone): Record<string, string> {
+  return {
+    '--trace-line-accent': traceLineToneColor(tone),
+  }
+}
+
+function traceLineToneColor(tone: TraceLineTone) {
+  switch (tone) {
+    case 'mixed':
+      return 'var(--vscode-charts-red, #f14c4c)'
+    case 'slow':
+      return 'var(--vscode-charts-orange, #d18616)'
+    case 'type-heavy':
+      return 'var(--vscode-charts-purple, #b180d7)'
+    case 'default':
+      return 'transparent'
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,37 @@
 import { describe, expect, it } from 'vitest'
+import { getTraceLineTone, getTraceLineToneStyle } from '../src/traceTone'
 
 describe('should', () => {
   it('exported', () => {
     expect(1).toEqual(1)
+  })
+
+  it('colors slow trace lines by duration', () => {
+    expect(getTraceLineTone({
+      line: { pid: 1, tid: 1, ph: 'X', cat: 'check', ts: 1, name: 'checkExpression', dur: 50_000 },
+      typeCnt: 0,
+      childTypeCnt: 0,
+    })).toBe('slow')
+  })
+
+  it('colors type-heavy trace lines separately from slow lines', () => {
+    expect(getTraceLineTone({
+      line: { pid: 1, tid: 1, ph: 'X', cat: 'check', ts: 1, name: 'checkExpression', dur: 10 },
+      typeCnt: 40,
+      childTypeCnt: 60,
+    })).toBe('type-heavy')
+  })
+
+  it('uses a mixed tone for slow and type-heavy trace lines', () => {
+    expect(getTraceLineTone({
+      line: { pid: 1, tid: 1, ph: 'X', cat: 'check', ts: 1, name: 'checkExpression', dur: 50_000 },
+      typeCnt: 100,
+      childTypeCnt: 0,
+    })).toBe('mixed')
+  })
+
+  it('uses theme variables for trace tone styles', () => {
+    expect(getTraceLineToneStyle('slow')['--trace-line-accent']).toContain('--vscode-charts-orange')
+    expect(getTraceLineToneStyle('type-heavy')['--trace-line-accent']).toContain('--vscode-charts-purple')
   })
 })

--- a/ui/components/TreeNode.vue
+++ b/ui/components/TreeNode.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Tree } from '../../src/traceTree'
+import { getTraceLineTone, getTraceLineToneStyle } from '../../src/traceTone'
 import { childrenById, typesById } from '~/src/appState'
 
 const props = defineProps<{ tree: Tree, depth: number }>()
@@ -8,6 +9,8 @@ const sendMessage = useNuxtApp().$sendMessage
 
 const children = computed(() => childrenById.get(props.tree.id) ?? [])
 const types = computed(() => typesById.get(props.tree.id) ?? [])
+const traceTone = computed(() => getTraceLineTone(props.tree))
+const traceToneStyle = computed(() => getTraceLineToneStyle(traceTone.value))
 
 function fetchChildren() {
   if (children.value.length === 0)
@@ -42,7 +45,7 @@ const insetClass = `border-e min-w-2 border-[var(--vscode-tree-inactiveIndentGui
         <!-- <div :class="insetClass" :style="{ minWidth: `${props.depth / 2}rem` }" /> -->
       </template>
       <template #label>
-        <div class="flex flex-row gap-5 w-full pl-1">
+        <div class="trace-line flex flex-row gap-5 w-full pl-1" :class="`trace-line--${traceTone}`" :style="traceToneStyle">
           <div class="flex flex-row justify-start gap-2 grow text-left">
             <span class="min-w-48">
               {{ tree.line.name }} ({{ tree.childCnt }}):
@@ -81,3 +84,21 @@ const insetClass = `border-e min-w-2 border-[var(--vscode-tree-inactiveIndentGui
     </UExpand>
   </div>
 </template>
+
+<style scoped>
+.trace-line {
+  border-left: 2px solid var(--trace-line-accent);
+  border-radius: 2px;
+  background-color: color-mix(in srgb, var(--trace-line-accent) 8%, transparent);
+}
+
+.trace-line--default {
+  background-color: transparent;
+}
+
+@supports not (background-color: color-mix(in srgb, red 8%, transparent)) {
+  .trace-line {
+    background-color: transparent;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- add VS Code theme-aware accent colors for slow, type-heavy, and mixed trace rows
- keep the tone calculation in a tested helper so thresholds are explicit
- remove package-manager caching from the tag release workflow

Fixes #40.

## Validation
- pnpm run typecheck
- pnpm exec vitest run test/index.test.ts
- pnpm exec eslint src/traceTone.ts ui/components/TreeNode.vue test/index.test.ts
- pnpm exec nuxt build ui
- pnpm exec rollup -c in srcDev
- pnpm exec rollup -c