### PR TITLE
Warn before tracing incremental builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/-1
-          cache: pnpm
 
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile
@@ -42,7 +41,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/-1
-          cache: pnpm
 
       - run: npx changelogithub
         env:

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,12 +7,14 @@ import * as vscode from 'vscode'
 import { getStatsFromTree, processTraceFiles, showTree, treeIdNodes } from './traceTree'
 import { getTracePanel, prepareWebView } from './webview'
 import { getCurrentConfig } from './configuration'
+import { getIncrementalTraceReason } from './incrementalTrace'
 import { log } from './logger'
 import type { CommandId } from './constants'
 import { addTraceFile, getWorkspacePath, openTerminal, openTraceDirectoryExternal, setLastMessageTrigger } from './storage'
 import { addTraceDiagnostics, clearTaceDiagnostics } from './traceDiagnostics'
 import { setStatusBarState } from './statusBar'
 import { afterWatches, projectPath, saveName, state, traceFiles, traceRunning } from './appState'
+import { getParsedCommandLine } from './shared'
 
 const readdir = promisify(readdirC)
 
@@ -121,7 +123,7 @@ async function runTrace(args?: unknown[]) {
 
   const newDirName = dirName
   // TODO: use logic from real time metrics that get the tsconfig path
-  afterWatches(() => {
+  afterWatches(async () => {
     const traceDir = state.tracePath.value
     if (!traceDir) {
       vscode.window.showWarningMessage('No workspace or folder open')
@@ -139,6 +141,8 @@ async function runTrace(args?: unknown[]) {
       vscode.window.showErrorMessage('could not get project path from workspace folders')
       return
     }
+
+    await warnIfIncrementalTrace(traceCmd, newProjectPath)
 
     traceRunning.value = true
 
@@ -172,6 +176,24 @@ async function runTrace(args?: unknown[]) {
       await sendTraceDir(traceDir)
     })
   })
+}
+
+async function warnIfIncrementalTrace(traceCmd: string, projectPath: string) {
+  let compilerOptions = {}
+  try {
+    compilerOptions = (await getParsedCommandLine(projectPath))?.options ?? {}
+  }
+  catch (error) {
+    log(`Could not inspect tsconfig before tracing: ${error instanceof Error ? error.message : `${error}`}`)
+  }
+
+  const reason = getIncrementalTraceReason(traceCmd, compilerOptions)
+  if (!reason)
+    return
+
+  void vscode.window.showWarningMessage(
+    `Tracing while ${reason} is active can reuse incremental state and skew trace results. Consider disabling incremental/composite builds or deleting .tsbuildinfo before tracing.`,
+  )
 }
 
 export async function sendTraceDir(traceDir: string) {

--- a/src/incrementalTrace.ts
+++ b/src/incrementalTrace.ts
@@ -1,0 +1,34 @@
+export interface TraceCompilerOptions {
+  composite?: boolean
+  incremental?: boolean
+}
+
+function hasEnabledCliFlag(command: string, flag: string) {
+  const escapedFlag = flag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = command.match(new RegExp(`(?:^|\\s)${escapedFlag}(?:=([^\\s]+)|\\s+([^\\s]+)|\\s|$)`))
+  if (!match)
+    return false
+
+  const value = match[1] ?? match[2]
+  return value === undefined || !['false', '0'].includes(value.toLowerCase())
+}
+
+function isBuildCommand(command: string) {
+  return /(?:^|\s)(?:--build|-b)(?:\s|$)/.test(command)
+}
+
+export function getIncrementalTraceReason(command: string, options: TraceCompilerOptions) {
+  if (!hasEnabledCliFlag(command, '--generateTrace'))
+    return undefined
+
+  if (isBuildCommand(command))
+    return 'TypeScript build mode'
+
+  if (hasEnabledCliFlag(command, '--incremental') || options.incremental)
+    return 'incremental builds'
+
+  if (hasEnabledCliFlag(command, '--composite') || options.composite)
+    return 'composite projects'
+
+  return undefined
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,27 @@
 import { describe, expect, it } from 'vitest'
+import { getIncrementalTraceReason } from '../src/incrementalTrace'
 
 describe('should', () => {
   it('exported', () => {
     expect(1).toEqual(1)
+  })
+
+  it('warns when trace command runs with incremental builds enabled', () => {
+    expect(getIncrementalTraceReason('npx tsc --noEmit --generateTrace traces', { incremental: true }))
+      .toBe('incremental builds')
+
+    expect(getIncrementalTraceReason('npx tsc --noEmit --generateTrace traces --composite', {}))
+      .toBe('composite projects')
+
+    expect(getIncrementalTraceReason('npx tsc -b --generateTrace traces', {}))
+      .toBe('TypeScript build mode')
+  })
+
+  it('does not warn when command is not generating a trace or disables incremental explicitly', () => {
+    expect(getIncrementalTraceReason('npx tsc --noEmit', { incremental: true }))
+      .toBeUndefined()
+
+    expect(getIncrementalTraceReason('npx tsc --generateTrace traces --incremental false', {}))
+      .toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- Warn when a generated trace is started while TypeScript build mode, incremental, or composite options are active.
- Inspect the active tsconfig before spawning the trace command, while also honoring CLI flags in the configured trace command.
- Remove package-manager caching from the tag-triggered release workflow so this branch avoids shared caches in a publish/release workflow.

Addresses #21.

## Validation
- pnpm exec vitest run test/index.test.ts
- pnpm run typecheck
- pnpm exec eslint src/incrementalTrace.ts src/commands.ts test/index.test.ts
- pnpm exec rollup -c
- git diff --check