### PR TITLE
feat: add slowTypeThresholdMs setting for highlighting complex types

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,12 @@
           "description": "command to open your preferred file browser. Use the ${traceDir} substitution variable",
           "order": 8
         },
+        "tsperf.tracer.slowTypeThresholdMs": {
+          "type": "number",
+          "default": 100,
+          "description": "Types taking longer than this many milliseconds will be highlighted as slow/complex",
+          "order": 9
+        },
         "tsperf.tracer.traceTimeThresholds": {
           "type": "object",
           "properties": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,7 +233,10 @@ async function runDiagnostics(collection: vscode.DiagnosticCollection, filePath:
     const duration = durations.reduce((a, b) => a + b, 0) / durations.length
     const proportionalTime = duration / baseline
 
-    if (proportionalTime > 1) {
+    const config = vscode.workspace.getConfiguration('tsperf.tracer')
+    const slowThreshold = config.get<number>('slowTypeThresholdMs', 100)
+
+    if (proportionalTime > 1 || duration > slowThreshold) {
       const comparisonPercentage = Math.round(proportionalTime * 100) - 100
       const sign = comparisonPercentage > 1 ? '+' : ''
       const logLevel = proportionalTime > 2


### PR DESCRIPTION
This PR adds a new configurable setting `tsperf.tracer.slowTypeThresholdMs` (default 100ms) that allows users to highlight types exceeding an absolute time threshold.

This directly addresses one of the "Help wanted" items in the repo and improves UX for the TSPerf challenge.

Related to Algora TSPerf bounty: https://algora.io/challenges/tsperf

Changes are minimal and focused.