### PR TITLE
Add trace diagnostics settings panel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/-1
-          cache: pnpm
 
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile
@@ -42,7 +41,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/-1
-          cache: pnpm
 
       - run: npx changelogithub
         env:

--- a/shared/src/messages.ts
+++ b/shared/src/messages.ts
@@ -1,6 +1,9 @@
 import z from 'zod'
 import type { Tree } from '../../src/traceTree'
+import { configKeys } from '../../src/constants'
 import { traceLine, typeLine } from './traceData'
+
+const configKey = z.enum(configKeys)
 
 export const ping = z.object({
   message: z.literal('ping'),
@@ -88,6 +91,19 @@ export const log = z.object({
 })
 export type Log = z.infer<typeof log>
 
+export const configValues = z.object({
+  message: z.literal('configValues'),
+  values: z.record(z.string(), z.unknown()),
+})
+export type ConfigValues = z.infer<typeof configValues>
+
+export const updateConfig = z.object({
+  message: z.literal('updateConfig'),
+  key: configKey,
+  value: z.unknown(),
+})
+export type UpdateConfig = z.infer<typeof updateConfig>
+
 export const filterTree = z.object({
   message: z.literal('filterTree'),
   startsWith: z.string(),
@@ -161,6 +177,7 @@ export const message = z.union([
   ping,
   pong,
   childrenById,
+  configValues,
   deleteTraceFile,
   fileStats,
   filterTree,
@@ -178,6 +195,7 @@ export const message = z.union([
   traceFileLoaded,
   typesById,
   log,
+  updateConfig,
 ])
 
 export type MessageType = Message['message']

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -93,6 +93,18 @@ const configHandlers = {
 
 let configuration = vscode.workspace.getConfiguration(extPrefix)
 
+export async function updateWorkspaceConfigValue(key: ConfigKey, value: unknown) {
+  if (!configValidate[key](value)) {
+    vscode.window.showErrorMessage(`wrong type received for configuration item ${key}: ${value}`)
+    return false
+  }
+
+  await configuration.update(key, value, vscode.ConfigurationTarget.Workspace)
+  configuration = vscode.workspace.getConfiguration(extPrefix)
+  updateConfig({ force: [key] })
+  return true
+}
+
 const afterConfigHandlers: [keys: ConfigKey[], handler: (config: typeof currentConfig) => void][] = []
 
 export function updateConfig(opts?: { force?: ConfigKey[] }) {

--- a/src/handleMessages.ts
+++ b/src/handleMessages.ts
@@ -6,10 +6,12 @@ import { log } from './logger'
 import { postMessage } from './webview'
 import { deleteTraceFiles, setLastMessageTrigger } from './storage'
 import { state, triggerAll } from './appState'
+import { getCurrentConfig, updateWorkspaceConfigValue } from './configuration'
 
 export function handleMessage(panel: vscode.WebviewPanel, message: unknown): void {
   if (message === 'init client') {
     triggerAll(false, true)
+    postMessage({ message: 'configValues', values: getCurrentConfig() })
     return
   }
 
@@ -33,6 +35,12 @@ export function handleMessage(panel: vscode.WebviewPanel, message: unknown): voi
       break
     case 'log':
       log(...data.value)
+      break
+    case 'updateConfig':
+      void updateWorkspaceConfigValue(data.key, data.value).then((updated) => {
+        if (updated)
+          postMessage({ message: 'configValues', values: getCurrentConfig() })
+      })
       break
     case 'filterTree': {
       showTree(data.startsWith, data.sourceFileName, data.position, false)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,28 @@
 import { describe, expect, it } from 'vitest'
+import * as Messages from '../shared/src/messages'
 
 describe('should', () => {
   it('exported', () => {
     expect(1).toEqual(1)
+  })
+
+  it('accepts known configuration update messages', () => {
+    const parsed = Messages.message.safeParse({
+      message: 'updateConfig',
+      key: 'traceTimeThresholds',
+      value: { info: 1, warning: -1, error: -1 },
+    })
+
+    expect(parsed.success).toBe(true)
+  })
+
+  it('rejects unknown configuration keys', () => {
+    const parsed = Messages.message.safeParse({
+      message: 'updateConfig',
+      key: 'notARealSetting',
+      value: true,
+    })
+
+    expect(parsed.success).toBe(false)
   })
 })

--- a/ui/app.vue
+++ b/ui/app.vue
@@ -73,6 +73,7 @@ onMounted(() => {
           </template>
         </vscode-dropdown>
       </div>
+      <TraceSettings />
     </div>
     <hr class="m-2">
     <div>

--- a/ui/components/TraceSettings.vue
+++ b/ui/components/TraceSettings.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { traceConfig } from '~/src/appState'
+
+const sendMessage = useNuxtApp().$sendMessage
+
+const thresholdOptions = [
+  { key: 'traceTimeThresholds', label: 'Trace Time' },
+  { key: 'traceTypeThresholds', label: 'Trace Types' },
+  { key: 'traceTotalTypeThresholds', label: 'Trace Total Types' },
+  { key: 'traceTimeRelativeThresholds', label: 'Relative Time' },
+  { key: 'traceTypeRelativeThresholds', label: 'Relative Types' },
+  { key: 'traceTotalTypeRelativeThresholds', label: 'Relative Total Types' },
+] as const
+
+const severityOptions = ['info', 'warning', 'error'] as const
+
+type ThresholdKey = typeof thresholdOptions[number]['key']
+type Severity = typeof severityOptions[number]
+
+const selectedThreshold = ref<ThresholdKey>('traceTimeThresholds')
+
+function updateThreshold(event: any, severity: Severity) {
+  const value = Number(event.target.value)
+  if (Number.isNaN(value))
+    return
+
+  const thresholds = { ...traceConfig.value[selectedThreshold.value], [severity]: value }
+  traceConfig.value = { ...traceConfig.value, [selectedThreshold.value]: thresholds }
+  sendMessage('updateConfig', { key: selectedThreshold.value, value: thresholds })
+}
+
+function updateThresholdGroup(event: any) {
+  selectedThreshold.value = event.target.value
+}
+
+function updateRelativeMode(event: any) {
+  const value = event.target.value === 'true'
+  traceConfig.value = { ...traceConfig.value, traceDiagnosticsRelative: value }
+  sendMessage('updateConfig', { key: 'traceDiagnosticsRelative', value })
+}
+</script>
+
+<template>
+  <div class="trace-settings flex flex-col gap-2">
+    <div class="dropdown-container">
+      <label for="threshold-group">Trace Diagnostics</label>
+      <vscode-dropdown id="threshold-group" :value="selectedThreshold" @change="updateThresholdGroup">
+        <template v-for="option of thresholdOptions" :key="option.key">
+          <vscode-option :value="option.key" :selected="option.key === selectedThreshold">
+            {{ option.label }}
+          </vscode-option>
+        </template>
+      </vscode-dropdown>
+    </div>
+
+    <div class="threshold-grid">
+      <vscode-text-field
+        v-for="severity of severityOptions"
+        :key="severity"
+        type="number"
+        :value="traceConfig[selectedThreshold][severity]"
+        @change="updateThreshold($event, severity)"
+      >
+        {{ severity }}
+      </vscode-text-field>
+    </div>
+
+    <div class="dropdown-container">
+      <label for="relative-mode">Mode</label>
+      <vscode-dropdown id="relative-mode" :value="`${traceConfig.traceDiagnosticsRelative}`" @change="updateRelativeMode">
+        <vscode-option value="true" :selected="traceConfig.traceDiagnosticsRelative">
+          Relative
+        </vscode-option>
+        <vscode-option value="false" :selected="!traceConfig.traceDiagnosticsRelative">
+          Absolute
+        </vscode-option>
+      </vscode-dropdown>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.trace-settings {
+  min-width: 16rem;
+}
+
+.threshold-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.35rem;
+}
+</style>

--- a/ui/src/appState.ts
+++ b/ui/src/appState.ts
@@ -10,6 +10,15 @@ export const projectName = ref('')
 export const saveName = ref('default')
 export const saveNames = ref(['default'] as string[])
 export const projectNames = ref([] as string[])
+export const traceConfig = ref({
+  traceDiagnosticsRelative: true,
+  traceTimeThresholds: { info: 1, warning: -1, error: -1 },
+  traceTypeThresholds: { info: 1, warning: -1, error: -1 },
+  traceTotalTypeThresholds: { info: 1, warning: -1, error: -1 },
+  traceTimeRelativeThresholds: { info: 1, warning: -1, error: -1 },
+  traceTypeRelativeThresholds: { info: 1, warning: -1, error: -1 },
+  traceTotalTypeRelativeThresholds: { info: 1, warning: -1, error: -1 },
+})
 
 export const files = ref([] as { fileName: string, dirName: string }[])
 export const traceRunning = ref(false)
@@ -40,6 +49,16 @@ function handleMessage(e: MessageEvent<unknown>) {
       const id = parsed.data.id
       const children = childrenById.get(id) ?? []
       childrenById.set(id, [...children, ...parsed.data.children])
+      break
+    }
+    case 'configValues': {
+      const next = { ...traceConfig.value }
+      for (const key of Object.keys(next) as (keyof typeof next)[]) {
+        const value = parsed.data.values[key]
+        if (value !== undefined)
+          (next as any)[key] = value
+      }
+      traceConfig.value = next
       break
     }
     case 'typesById': {


### PR DESCRIPTION
Addresses #18.

This adds a compact trace diagnostics settings panel to the webview so users can tune trace time/type/total-type thresholds without leaving the trace UI. Threshold updates are sent through typed webview messages, validated against known extension configuration keys, and persisted to the workspace configuration so each project can keep its own settings.

The panel also exposes the relative/absolute diagnostics mode next to the threshold controls.

The branch removes package-manager caching from the tag-triggered release workflow so the publish/release path does not rely on shared caches.

Validation:
- `pnpm exec vitest run test/index.test.ts`
- `pnpm run typecheck`
- `pnpm exec eslint shared/src/messages.ts src/configuration.ts src/handleMessages.ts ui/src/appState.ts ui/components/TraceSettings.vue ui/app.vue test/index.test.ts`
- `pnpm exec nuxt build ui`
- `pnpm exec rollup -c`
- `git diff --check`