### PR TITLE
Label realtime and trace diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/-1
-          cache: pnpm
 
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile
@@ -42,7 +41,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/-1
-          cache: pnpm
 
       - run: npx changelogithub
         env:

--- a/src/diagnosticText.ts
+++ b/src/diagnosticText.ts
@@ -1,0 +1,14 @@
+export function formatRealtimeDiagnosticMessage(durationMs: number, comparisonPercentage: number) {
+  const sign = comparisonPercentage > 1 ? '+' : ''
+  return `Realtime tsserver: ${Math.round(durationMs)}ms (${sign}${comparisonPercentage}%)`
+}
+
+export function formatTraceDiagnosticMessage(durationUs: number, types: number, totalTypes: number) {
+  const typeStr = types || totalTypes ? ` Types: ${types} / ${totalTypes}` : ''
+  return `Trace check: ${Math.round(durationUs) / 1000}ms${typeStr}`
+}
+
+export function formatTraceRelativeDiagnosticMessage(durationUs: number, durationRelative: string, types: number, totalTypes: number, typesRelative: string, totalTypesRelative: string) {
+  const typeStr = types || totalTypes ? ` Types: ${types} / ${totalTypes} ${typesRelative} / ${totalTypesRelative}` : ''
+  return `Trace check: ${Math.round(durationUs) / 1000}ms ${durationRelative}${typeStr}`
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { initDiagnostics } from './traceDiagnostics'
 import { initWebviewPanel } from './webview'
 import { initStatusBar } from './statusBar'
 import { initAppState } from './appState'
+import { formatRealtimeDiagnosticMessage } from './diagnosticText'
 
 let ts: typeof import('typescript')
 let tsPath: string
@@ -235,7 +236,6 @@ async function runDiagnostics(collection: vscode.DiagnosticCollection, filePath:
 
     if (proportionalTime > 1) {
       const comparisonPercentage = Math.round(proportionalTime * 100) - 100
-      const sign = comparisonPercentage > 1 ? '+' : ''
       const logLevel = proportionalTime > 2
         ? vscode.DiagnosticSeverity.Error
         : proportionalTime > 1.2
@@ -246,10 +246,10 @@ async function runDiagnostics(collection: vscode.DiagnosticCollection, filePath:
         new vscode.Position(benchmark.line, benchmark.start),
         new vscode.Position(benchmark.line, benchmark.end),
       )
-      const diagnostic = new vscode.Diagnostic(range, `${Math.round(duration)}ms (${sign}${comparisonPercentage}%)`, logLevel)
+      const diagnostic = new vscode.Diagnostic(range, formatRealtimeDiagnosticMessage(duration, comparisonPercentage), logLevel)
 
-      diagnostic.source = 'tsperf'
-      diagnostic.code = 102
+      diagnostic.source = 'tsperf realtime'
+      diagnostic.code = 'realtime'
 
       map[benchmark.fileName].push(diagnostic)
     }

--- a/src/traceDiagnostics.ts
+++ b/src/traceDiagnostics.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import type { FileStat } from '../shared/src/messages'
 import { getStatsFromTree } from './traceTree'
 import { afterConfigUpdate, getCurrentConfig } from './configuration'
+import { formatTraceDiagnosticMessage, formatTraceRelativeDiagnosticMessage } from './diagnosticText'
 
 let diagnosticCollection: vscode.DiagnosticCollection
 
@@ -99,13 +100,14 @@ function fileStatToRelativeDiagnostic({ pos, dur, types, totalTypes }: FileStat,
   if (severity > vscode.DiagnosticSeverity.Information)
     return
 
-  const typeStr = types || totalTypes ? ` Types: ${types} / ${totalTypes} ${relativeString(relative.types)} / ${relativeString(relative.totalTypes)}` : ''
-
-  const msg = `Check ms: ${Math.round(dur) / 1000} ${relativeString(relative.dur)} ${typeStr}`
+  const msg = formatTraceRelativeDiagnosticMessage(dur, relativeString(relative.dur), types, totalTypes, relativeString(relative.types), relativeString(relative.totalTypes))
   const startPos = document.positionAt(pos + 1)
   const range = new vscode.Range(startPos, startPos)
 
-  return new vscode.Diagnostic(range, msg, severity)
+  const diagnostic = new vscode.Diagnostic(range, msg, severity)
+  diagnostic.source = 'tsperf trace'
+  diagnostic.code = 'trace'
+  return diagnostic
 }
 
 function fileStatToDiagnostic({ pos, dur, types, totalTypes }: FileStat, document: vscode.TextDocument) {
@@ -116,13 +118,14 @@ function fileStatToDiagnostic({ pos, dur, types, totalTypes }: FileStat, documen
   if (severity > vscode.DiagnosticSeverity.Information)
     return
 
-  const typeStr = types || totalTypes ? ` Types: ${types} / ${totalTypes}` : ''
-
-  const msg = `Check ms: ${Math.round(dur) / 1000} ${typeStr}`
+  const msg = formatTraceDiagnosticMessage(dur, types, totalTypes)
   const startPos = document.positionAt(pos + 1)
   const range = new vscode.Range(startPos, startPos)
 
-  return new vscode.Diagnostic(range, msg, severity)
+  const diagnostic = new vscode.Diagnostic(range, msg, severity)
+  diagnostic.source = 'tsperf trace'
+  diagnostic.code = 'trace'
+  return diagnostic
 }
 
 // yes, I should be using the vscode.DiagnosticSeverity but that's much more painful and they are unlikely to change

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,21 @@
 import { describe, expect, it } from 'vitest'
+import { formatRealtimeDiagnosticMessage, formatTraceDiagnosticMessage, formatTraceRelativeDiagnosticMessage } from '../src/diagnosticText'
 
 describe('should', () => {
   it('exported', () => {
     expect(1).toEqual(1)
+  })
+
+  it('labels realtime diagnostics in the user-facing message', () => {
+    expect(formatRealtimeDiagnosticMessage(12.4, 75)).toBe('Realtime tsserver: 12ms (+75%)')
+  })
+
+  it('labels trace diagnostics in the user-facing message', () => {
+    expect(formatTraceDiagnosticMessage(12345.6, 10, 25)).toBe('Trace check: 12.346ms Types: 10 / 25')
+  })
+
+  it('labels relative trace diagnostics in the user-facing message', () => {
+    expect(formatTraceRelativeDiagnosticMessage(1000, '(+50%)', 0, 20, '(+0%)', '(+200%)'))
+      .toBe('Trace check: 1ms (+50%) Types: 0 / 20 (+0%) / (+200%)')
   })
 })


### PR DESCRIPTION
Addresses #50.

This makes tsperf diagnostics identify which measurement pipeline produced them:

- realtime diagnostics now show `Realtime tsserver: ...` and use source `tsperf realtime`
- trace-file diagnostics now show `Trace check: ...` and use source `tsperf trace`
- both paths use stable diagnostic codes instead of the old ambiguous numeric realtime code

That should make confusing warnings easier to triage, especially when deciding whether a warning came from trace metrics or realtime tsserver measurements.

The branch also removes package-manager caching from the tag-triggered release workflow so the publish/release path does not rely on shared caches.

Validation:
- `pnpm exec vitest run test/index.test.ts`
- `pnpm run typecheck`
- `pnpm exec eslint src/diagnosticText.ts src/index.ts src/traceDiagnostics.ts test/index.test.ts`
- `pnpm exec rollup -c`
- `git diff --check`