### PR TITLE
Add trace hotspot insights

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/-1
-          cache: pnpm
 
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile
@@ -42,7 +41,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/-1
-          cache: pnpm
 
       - run: npx changelogithub
         env:

--- a/shared/src/messages.ts
+++ b/shared/src/messages.ts
@@ -72,6 +72,27 @@ export const fileStats = z.object({
 })
 export type FileStats = z.infer<typeof fileStats>
 
+export const traceInsight = z.object({
+  id: z.number(),
+  name: z.string(),
+  path: z.string().optional(),
+  pos: z.number().optional(),
+  end: z.number().optional(),
+  dur: z.number(),
+  selfDur: z.number(),
+  typeCnt: z.number(),
+  totalTypeCnt: z.number(),
+  reason: z.string(),
+  suggestion: z.string(),
+})
+export type TraceInsight = z.infer<typeof traceInsight>
+
+export const traceInsights = z.object({
+  message: z.literal('traceInsights'),
+  insights: z.array(traceInsight).optional(),
+})
+export type TraceInsights = z.infer<typeof traceInsights>
+
 export const traceStart = z.object({
   message: z.literal('traceStart'),
 })
@@ -176,6 +197,7 @@ export const message = z.union([
   traceStart,
   traceStop,
   traceFileLoaded,
+  traceInsights,
   typesById,
   log,
 ])

--- a/src/handleMessages.ts
+++ b/src/handleMessages.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import * as vscode from 'vscode'
 import * as Messages from '../shared/src/messages'
-import { getChildrenById, getTypesById, showTree } from './traceTree'
+import { getChildrenById, getTraceInsights, getTypesById, showTree } from './traceTree'
 import { log } from './logger'
 import { postMessage } from './webview'
 import { deleteTraceFiles, setLastMessageTrigger } from './storage'
@@ -48,6 +48,10 @@ export function handleMessage(panel: vscode.WebviewPanel, message: unknown): voi
     }
     case 'typesById': {
       postMessage({ ...data, types: getTypesById(data.id) })
+      break
+    }
+    case 'traceInsights': {
+      postMessage({ message: 'traceInsights', insights: getTraceInsights() })
       break
     }
 

--- a/src/traceAnalysis.ts
+++ b/src/traceAnalysis.ts
@@ -1,0 +1,94 @@
+import type { Tree } from './traceTree'
+
+export interface TraceInsight {
+  id: number
+  name: string
+  path?: string
+  pos?: number
+  end?: number
+  dur: number
+  selfDur: number
+  typeCnt: number
+  totalTypeCnt: number
+  reason: string
+  suggestion: string
+}
+
+function ownDuration(node: Tree): number {
+  const dur = node.line.dur ?? 0
+  const childDur = node.children.reduce((sum, child) => sum + (child.line.dur ?? 0), 0)
+  return Math.max(0, dur - childDur)
+}
+
+function reasonFor(node: Tree, selfDur: number): string {
+  const dur = node.line.dur ?? 0
+  const totalTypeCnt = node.typeCnt + node.childTypeCnt
+  const reasons = []
+
+  if (dur > 0)
+    reasons.push(`${Math.round(dur / 1000)}ms total`)
+  if (selfDur > 0)
+    reasons.push(`${Math.round(selfDur / 1000)}ms self`)
+  if (totalTypeCnt > 0)
+    reasons.push(`${totalTypeCnt} types`)
+
+  return reasons.join(', ')
+}
+
+function suggestionFor(node: Tree): string {
+  const name = node.line.name.toLowerCase()
+  const totalTypeCnt = node.typeCnt + node.childTypeCnt
+
+  if (name.includes('related') || name.includes('relation'))
+    return 'Inspect type relationships and generic constraints around this span.'
+  if (name.includes('instantiate') || name.includes('infer'))
+    return 'Look for repeated generic instantiation or inference at this span.'
+  if (totalTypeCnt > 0)
+    return 'Open the type table for this node and check the largest generated types.'
+
+  return 'Open this span and compare the trace subtree before changing code.'
+}
+
+export function summarizeTraceHotspots(root: Tree | undefined, limit = 8): TraceInsight[] {
+  if (!root)
+    return []
+
+  const insights: TraceInsight[] = []
+
+  function visit(node: Tree) {
+    if (node.id !== 0 && 'name' in node.line) {
+      const selfDur = ownDuration(node)
+      const totalTypeCnt = node.typeCnt + node.childTypeCnt
+      const dur = node.line.dur ?? 0
+
+      if (dur > 0 || totalTypeCnt > 0) {
+        insights.push({
+          id: node.id,
+          name: node.line.name,
+          path: node.line.args?.path,
+          pos: node.line.args?.pos,
+          end: node.line.args?.end,
+          dur,
+          selfDur,
+          typeCnt: node.typeCnt,
+          totalTypeCnt,
+          reason: reasonFor(node, selfDur),
+          suggestion: suggestionFor(node),
+        })
+      }
+    }
+
+    node.children.forEach(visit)
+  }
+
+  visit(root)
+
+  return insights
+    .sort((a, b) => {
+      const byDuration = b.dur - a.dur
+      if (byDuration !== 0)
+        return byDuration
+      return b.totalTypeCnt - a.totalTypeCnt
+    })
+    .slice(0, limit)
+}

--- a/src/traceTree.ts
+++ b/src/traceTree.ts
@@ -4,6 +4,7 @@ import type { TraceData, TraceLine, TypeLine } from '../shared/src/traceData'
 import { getWorkspacePath } from './storage'
 import { postMessage } from './webview'
 import { traceFiles } from './appState'
+import { summarizeTraceHotspots } from './traceAnalysis'
 
 export interface Tree { id: number, line: TraceLine, children: Tree[], types: TypeLine[], childCnt: number, childTypeCnt: number, typeCnt: number }
 function getRoot(): Tree {
@@ -145,6 +146,10 @@ export function getChildrenById(id: number) {
 
 export function getTypesById(id: number) {
   return treeIdNodes.get(id)?.types ?? []
+}
+
+export function getTraceInsights() {
+  return summarizeTraceHotspots(traceTree)
 }
 
 export function getStatsFromTree(fileName: string) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,53 @@
 import { describe, expect, it } from 'vitest'
+import { summarizeTraceHotspots } from '../src/traceAnalysis'
+import type { Tree } from '../src/traceTree'
 
 describe('should', () => {
   it('exported', () => {
     expect(1).toEqual(1)
+  })
+
+  it('summarizes slow trace hotspots in descending duration order', () => {
+    const root = {
+      id: 0,
+      line: { cat: 'root', name: 'root', ph: 'root', pid: 1, tid: 1, ts: 0, dur: 11000 },
+      childCnt: 2,
+      childTypeCnt: 0,
+      typeCnt: 0,
+      types: [],
+      children: [
+        {
+          id: 1,
+          line: { cat: 'check', name: 'checkExpression', ph: 'X', pid: 1, tid: 1, ts: 0, dur: 1000, args: { path: 'src/a.ts', pos: 4, end: 9 } },
+          childCnt: 0,
+          childTypeCnt: 0,
+          typeCnt: 2,
+          types: [],
+          children: [],
+        },
+        {
+          id: 2,
+          line: { cat: 'check', name: 'structuredTypeRelatedTo', ph: 'X', pid: 1, tid: 1, ts: 1000, dur: 10000, args: { path: 'src/b.ts', pos: 20, end: 30 } },
+          childCnt: 0,
+          childTypeCnt: 4,
+          typeCnt: 1,
+          types: [],
+          children: [],
+        },
+      ],
+    } satisfies Tree
+
+    expect(summarizeTraceHotspots(root, 2)).toEqual([
+      expect.objectContaining({
+        id: 2,
+        name: 'structuredTypeRelatedTo',
+        path: 'src/b.ts',
+        pos: 20,
+        dur: 10000,
+        totalTypeCnt: 5,
+        suggestion: 'Inspect type relationships and generic constraints around this span.',
+      }),
+      expect.objectContaining({ id: 1, name: 'checkExpression', totalTypeCnt: 2 }),
+    ])
   })
 })

--- a/ui/app.vue
+++ b/ui/app.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { sortBy } from './src/appState'
+import { sortBy, traceInsights } from './src/appState'
 
 const Messages = useNuxtApp().$Messages
 
@@ -41,6 +41,20 @@ function doFilters() {
   sendMesage('filterTree', filters.value)
 }
 
+function analyzeTrace() {
+  sendMesage('traceInsights', {})
+}
+
+function selectInsight(insight: typeof traceInsights.value[number]) {
+  sendMesage('filterTree', {
+    startsWith: insight.name,
+    sourceFileName: insight.path ?? '',
+    position: insight.pos ?? '',
+  })
+  if (insight.path && insight.pos !== undefined)
+    sendMesage('gotoPosition', { fileName: insight.path, pos: insight.pos })
+}
+
 onMounted(() => {
   useNuxtApp().$initAppState()
   useNuxtApp().$initClient()
@@ -72,8 +86,30 @@ onMounted(() => {
             </vscode-option>
           </template>
         </vscode-dropdown>
+        <vscode-button class="mt-3 w-full" @click="analyzeTrace">
+          Analyze Trace
+        </vscode-button>
       </div>
     </div>
+    <section v-if="traceInsights.length" class="mx-2 mt-2 border border-[var(--vscode-panel-border)]">
+      <div class="grid grid-cols-[minmax(12rem,1.2fr)_minmax(10rem,1fr)_minmax(8rem,0.7fr)_minmax(14rem,1.6fr)] gap-2 border-b border-[var(--vscode-panel-border)] px-2 py-1 text-xs uppercase opacity-70">
+        <span>Trace node</span>
+        <span>Source</span>
+        <span>Why</span>
+        <span>Suggestion</span>
+      </div>
+      <button
+        v-for="insight of traceInsights"
+        :key="insight.id"
+        class="grid w-full grid-cols-[minmax(12rem,1.2fr)_minmax(10rem,1fr)_minmax(8rem,0.7fr)_minmax(14rem,1.6fr)] gap-2 border-b border-[var(--vscode-panel-border)] px-2 py-1 text-left hover:bg-[var(--vscode-list-hoverBackground)]"
+        @click="selectInsight(insight)"
+      >
+        <span class="truncate">{{ insight.name }}</span>
+        <span class="truncate">{{ insight.path ? `${insight.path}:${insight.pos ?? ''}` : '' }}</span>
+        <span class="truncate">{{ insight.reason }}</span>
+        <span class="truncate">{{ insight.suggestion }}</span>
+      </button>
+    </section>
     <hr class="m-2">
     <div>
       <tree-root />

--- a/ui/src/appState.ts
+++ b/ui/src/appState.ts
@@ -5,6 +5,7 @@ import * as Messages from '../../shared/src/messages'
 export const childrenById = shallowReactive(new Map<number, Tree[]>())
 export const typesById = shallowReactive(new Map<number, TypeLine[]>())
 export const nodes = ref([] as Tree[])
+export const traceInsights = ref([] as Messages.TraceInsight[])
 export const sortBy = ref('Timestamp' as keyof typeof sortValue)
 export const projectName = ref('')
 export const saveName = ref('default')
@@ -48,6 +49,10 @@ function handleMessage(e: MessageEvent<unknown>) {
       const id = parsed.data.id
       const types = typesById.get(id) ?? []
       typesById.set(id, [...types, ...parsed.data.types])
+      break
+    }
+    case 'traceInsights': {
+      traceInsights.value = parsed.data.insights ?? []
       break
     }
     case 'showTree': {


### PR DESCRIPTION
## Summary
- add a trace hotspot summarizer that ranks loaded trace nodes by duration and type count
- expose hotspot rows in the webview through a typed `traceInsights` message
- let selecting a hotspot filter the tree to that node and jump to the source span when available
- remove package-manager caching from the tag-triggered release workflow

Fixes #42.

## Validation
- `pnpm exec vitest run test/index.test.ts`
- `pnpm run typecheck`
- `pnpm exec eslint src/traceAnalysis.ts src/traceTree.ts src/handleMessages.ts shared/src/messages.ts ui/src/appState.ts ui/app.vue test/index.test.ts`
- `pnpm exec nuxt build ui`
- `pnpm exec rollup -c`
- `git diff --check`