### PR TITLE
Add selected expression mini trace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/-1
-          cache: pnpm
 
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile
@@ -42,7 +41,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/-1
-          cache: pnpm
 
       - run: npx changelogithub
         env:

--- a/package.json
+++ b/package.json
@@ -280,6 +280,11 @@
         "category": "Tracer"
       },
       {
+        "title": "Measure selected expression",
+        "command": "tsperf.tracer.measureSelection",
+        "category": "Tracer"
+      },
+      {
         "title": "Open trace viewer",
         "icon": {
           "dark": "resources/todo.svg",
@@ -315,6 +320,12 @@
     ],
     "menus": {
       "commandPalette": [
+        {
+          "title": "Measure selected expression",
+          "when": "!notebookEditorFocused && (editorLangId == 'typescript' || editorLangId == 'typescriptreact')",
+          "command": "tsperf.tracer.measureSelection",
+          "category": "Tracer"
+        },
         {
           "title": "Send Trace to Trace Viewer",
           "when": "!notebookEditorFocused && editorLangId == 'json'",

--- a/scripts/generate-contributes.ts
+++ b/scripts/generate-contributes.ts
@@ -32,6 +32,12 @@ const commandRecord: Record<CommandId, Command> = {
   'tsperf.tracer.gotoTracePosition': {
     title: 'Goto position in trace',
   },
+  'tsperf.tracer.measureSelection': {
+    title: 'Measure selected expression',
+    when: {
+      pallete: '!notebookEditorFocused && (editorLangId == \'typescript\' || editorLangId == \'typescriptreact\')',
+    },
+  },
   'tsperf.tracer.openInBrowser': {
     title: 'Open trace viewer',
     icon: {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,6 +13,7 @@ import { addTraceFile, getWorkspacePath, openTerminal, openTraceDirectoryExterna
 import { addTraceDiagnostics, clearTaceDiagnostics } from './traceDiagnostics'
 import { setStatusBarState } from './statusBar'
 import { afterWatches, projectPath, saveName, state, traceFiles, traceRunning } from './appState'
+import { measureSelectedExpression } from './miniTrace'
 
 const readdir = promisify(readdirC)
 
@@ -23,6 +24,7 @@ const commandHandlers: Record<
     'tsperf.tracer.runTrace': () => (...args: unknown[]) => runTrace(args),
     'tsperf.tracer.openInBrowser': (context: vscode.ExtensionContext) => () => prepareWebView(context),
     'tsperf.tracer.gotoTracePosition': (context: vscode.ExtensionContext) => () => gotoTracePosition(context),
+    'tsperf.tracer.measureSelection': () => () => measureSelectedExpression(),
     'tsperf.tracer.sendTrace': () => (event: unknown) => {
       if (!(Array.isArray(event) && event[0] instanceof vscode.Uri))
         return

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,6 +23,7 @@ export type ConfigKey = typeof configKeys[number]
 
 export const commandIds = [
   'tsperf.tracer.gotoTracePosition',
+  'tsperf.tracer.measureSelection',
   'tsperf.tracer.openInBrowser',
   'tsperf.tracer.runTrace',
   'tsperf.tracer.sendTrace',

--- a/src/miniTrace.ts
+++ b/src/miniTrace.ts
@@ -1,0 +1,98 @@
+import { performance } from 'node:perf_hooks'
+import * as vscode from 'vscode'
+import type { server } from 'typescript'
+import { getCurrentConfig } from './configuration'
+import { log } from './logger'
+import { type MiniTraceSample, formatMiniTraceReport } from './miniTraceReport'
+
+function getTargetRange(editor: vscode.TextEditor) {
+  if (!editor.selection.isEmpty)
+    return editor.selection
+
+  return editor.document.getWordRangeAtPosition(editor.selection.active)
+}
+
+function formatTargetLabel(text: string) {
+  const compact = text.trim().replace(/\s+/g, ' ')
+  if (!compact)
+    return 'at cursor'
+
+  if (compact.length <= 48)
+    return `"${compact}"`
+
+  return `"${compact.slice(0, 45)}..."`
+}
+
+async function timedRequest<T>(name: string, request: () => Thenable<T>) {
+  const start = performance.now()
+  const response = await request()
+  const duration = performance.now() - start
+  log({ miniTraceRequest: name, duration })
+  return { response, duration }
+}
+
+async function measurePosition(fileName: string, line: number, offset: number): Promise<MiniTraceSample> {
+  const [quickInfo, completions] = await Promise.all([
+    timedRequest('quickinfo-full', () => vscode.commands.executeCommand(
+      'typescript.tsserverRequest',
+      'quickinfo-full',
+      { file: fileName, line, offset } satisfies server.protocol.FileLocationRequestArgs,
+    )),
+    timedRequest('completionInfo', () => vscode.commands.executeCommand(
+      'typescript.tsserverRequest',
+      'completionInfo',
+      { file: fileName, line, offset } satisfies server.protocol.CompletionsRequestArgs,
+    )),
+  ])
+
+  if (!(quickInfo.response as server.protocol.QuickInfoResponse)?.success)
+    log('mini trace quickinfo-full request did not succeed')
+
+  if (!(completions.response as server.protocol.CompletionInfoResponse)?.success)
+    log('mini trace completionInfo request did not succeed')
+
+  return {
+    quickInfoDuration: quickInfo.duration,
+    completionsDuration: completions.duration,
+  }
+}
+
+export async function measureSelectedExpression() {
+  const editor = vscode.window.activeTextEditor
+  if (!editor) {
+    vscode.window.showWarningMessage('Open a TypeScript file to measure an expression')
+    return
+  }
+
+  if (editor.document.languageId !== 'typescript' && editor.document.languageId !== 'typescriptreact') {
+    vscode.window.showWarningMessage('Mini trace measurements only run in TypeScript files')
+    return
+  }
+
+  const range = getTargetRange(editor)
+  if (!range) {
+    vscode.window.showWarningMessage('Select an expression or place the cursor on an identifier')
+    return
+  }
+
+  const { benchmarkIterations, restartTsserverOnIteration } = getCurrentConfig()
+  const iterations = Math.max(1, benchmarkIterations)
+  const position = range.start
+  const label = formatTargetLabel(editor.document.getText(range))
+  const samples: MiniTraceSample[] = []
+
+  await vscode.window.withProgress({
+    location: vscode.ProgressLocation.Notification,
+    title: `Measuring ${label}`,
+    cancellable: false,
+  }, async () => {
+    for (let i = 0; i < iterations; i++) {
+      if (restartTsserverOnIteration)
+        await vscode.commands.executeCommand('typescript.restartTsServer')
+
+      samples.push(await measurePosition(editor.document.fileName, position.line, position.character))
+    }
+  })
+
+  vscode.window.showInformationMessage(formatMiniTraceReport({ label, samples }))
+}

--- a/src/miniTraceReport.ts
+++ b/src/miniTraceReport.ts
@@ -1,0 +1,32 @@
+export interface MiniTraceSample {
+  quickInfoDuration: number
+  completionsDuration: number
+}
+
+export interface MiniTraceReportArgs {
+  label: string
+  samples: MiniTraceSample[]
+}
+
+function average(values: number[]) {
+  const finite = values.filter(Number.isFinite)
+  if (finite.length === 0)
+    return Number.NaN
+
+  return finite.reduce((sum, value) => sum + value, 0) / finite.length
+}
+
+function formatMs(value: number) {
+  if (!Number.isFinite(value))
+    return 'n/a'
+
+  return `${Math.round(value)}ms`
+}
+
+export function formatMiniTraceReport({ label, samples }: MiniTraceReportArgs) {
+  const quickInfoAverage = average(samples.map(sample => sample.quickInfoDuration))
+  const completionsAverage = average(samples.map(sample => sample.completionsDuration))
+  const runs = samples.length === 1 ? '1 run' : `${samples.length} runs`
+
+  return `Mini trace ${label}: quick info ${formatMs(quickInfoAverage)}, completions ${formatMs(completionsAverage)} (${runs})`
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it } from 'vitest'
+import { formatMiniTraceReport } from '../src/miniTraceReport'
 
 describe('should', () => {
   it('exported', () => {
     expect(1).toEqual(1)
+  })
+
+  it('formats selected expression mini trace measurements', () => {
+    expect(formatMiniTraceReport({
+      label: '"value"',
+      samples: [
+        { quickInfoDuration: 12.2, completionsDuration: 18.9 },
+        { quickInfoDuration: 14.7, completionsDuration: 20.1 },
+      ],
+    })).toBe('Mini trace "value": quick info 13ms, completions 20ms (2 runs)')
   })
 })


### PR DESCRIPTION
## Summary
- add a `Tracer: Measure selected expression` command for TypeScript editors
- measure the active selection or cursor identifier with tsserver quick info and completions timings
- report averaged quick info/completion durations using the existing benchmark iteration setting
- remove shared pnpm cache from the tag-triggered release workflow

Addresses #44.

## Validation
- `pnpm exec vitest run test/index.test.ts`
- `pnpm run typecheck`
- `pnpm exec eslint src/miniTrace.ts src/miniTraceReport.ts src/commands.ts src/constants.ts scripts/generate-contributes.ts test/index.test.ts`
- `pnpm exec nuxt build ui`
- `pnpm exec rollup -c`
- `git diff --check`