### PR TITLE
feat: attach extended diagnostics to trace metrics

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,6 +13,7 @@ import { addTraceFile, getWorkspacePath, openTerminal, openTraceDirectoryExterna
 import { addTraceDiagnostics, clearTaceDiagnostics } from './traceDiagnostics'
 import { setStatusBarState } from './statusBar'
 import { afterWatches, projectPath, saveName, state, traceFiles, traceRunning } from './appState'
+import { TRACE_RUN_METRICS_FILE, buildTraceRunMetrics, discoverTraceJsonFiles, summarizeTraceParse, writeTraceRunMetrics } from './traceRunMetrics'
 
 const readdir = promisify(readdirC)
 
@@ -148,21 +149,50 @@ async function runTrace(args?: unknown[]) {
     setStatusBarState('traceError', false)
 
     log(`shell: ${process.env.SHELL}`)
+    const startedAtMs = Date.now()
+    const startedAt = new Date(startedAtMs).toISOString()
     const cmdProcess = spawn(fullCmd, [], { cwd: newProjectPath, shell: process.env.SHELL })
 
     let err = ''
+    let out = ''
     cmdProcess.stderr.on('data', data => err += data.toString())
 
-    cmdProcess.stdout.on('data', data => log(data.toString()))
+    cmdProcess.stdout.on('data', (data) => {
+      const chunk = data.toString()
+      out += chunk
+      log(chunk)
+    })
 
-    cmdProcess.on('error', (error) => {
+    let metricsWritten = false
+    async function writeMetricsOnce(exitCode: number | null) {
+      if (metricsWritten)
+        return
+
+      metricsWritten = true
+      await writeRunMetrics({
+        command: fullCmd,
+        cwd: newProjectPath,
+        traceDir,
+        startedAt,
+        startedAtMs,
+        exitCode,
+        stdout: out,
+        stderr: err,
+      })
+    }
+
+    cmdProcess.on('error', async (error) => {
+      traceRunning.value = false
+      setStatusBarState('traceError', true)
       vscode.window.showErrorMessage(error.message)
+      await writeMetricsOnce(null)
     })
 
     cmdProcess.on('exit', async (code) => {
       log('---- trace stderr -----')
       log(err)
       traceRunning.value = false
+      await writeMetricsOnce(code)
       if (code) {
         setStatusBarState('traceError', true)
         vscode.window.showErrorMessage('error running trace')
@@ -174,6 +204,41 @@ async function runTrace(args?: unknown[]) {
   })
 }
 
+async function writeRunMetrics(input: {
+  command: string
+  cwd: string
+  traceDir: string
+  startedAt: string
+  startedAtMs: number
+  exitCode: number | null
+  stdout: string
+  stderr: string
+}) {
+  try {
+    const traceJsonFiles = existsSync(input.traceDir) ? await discoverTraceJsonFiles(input.traceDir) : []
+    const parseSummary = existsSync(input.traceDir)
+      ? await summarizeTraceParse(input.traceDir, traceJsonFiles)
+      : { status: 'missing' as const, topLevelWarning: 'Trace directory was not created.' }
+
+    await writeTraceRunMetrics(input.traceDir, buildTraceRunMetrics({
+      command: input.command,
+      cwd: input.cwd,
+      traceDir: input.traceDir,
+      startedAt: input.startedAt,
+      endedAt: new Date().toISOString(),
+      wallTimeMs: Date.now() - input.startedAtMs,
+      exitCode: input.exitCode,
+      stdout: input.stdout,
+      stderr: input.stderr,
+      traceJsonFiles,
+      parseSummary,
+    }))
+  }
+  catch (error) {
+    log(`error writing trace metrics: ${error instanceof Error ? error.message : `${error}`}`)
+  }
+}
+
 export async function sendTraceDir(traceDir: string) {
   try {
     if (!existsSync(traceDir)) {
@@ -182,6 +247,9 @@ export async function sendTraceDir(traceDir: string) {
 
     const fileNames = await readdir(traceDir)
     for (const fileName of fileNames) {
+      if (fileName === TRACE_RUN_METRICS_FILE)
+        continue
+
       sendTrace(traceDir, fileName)
     }
   }

--- a/src/extendedDiagnostics.ts
+++ b/src/extendedDiagnostics.ts
@@ -1,0 +1,182 @@
+export type ExtendedDiagnosticUnit = 'count' | 'kb' | 'ms'
+
+export interface ExtendedDiagnosticMetric {
+  value: number
+  unit: ExtendedDiagnosticUnit
+  raw: string
+}
+
+export interface ExtendedDiagnosticsSummary {
+  files?: number
+  lines?: {
+    total?: number
+    library?: number
+    definitions?: number
+    typescript?: number
+    javascript?: number
+    json?: number
+    other?: number
+  }
+  identifiers?: number
+  symbols?: number
+  types?: number
+  instantiations?: number
+  memoryUsedKb?: number
+  parseTimeMs?: number
+  bindTimeMs?: number
+  checkTimeMs?: number
+  emitTimeMs?: number
+  totalTimeMs?: number
+  metrics: Record<string, ExtendedDiagnosticMetric>
+}
+
+const metricKeysByLabel = new Map<string, string>([
+  ['files', 'files'],
+  ['lines', 'lines'],
+  ['lines of library', 'linesOfLibrary'],
+  ['lines of definitions', 'linesOfDefinitions'],
+  ['lines of typescript', 'linesOfTypeScript'],
+  ['lines of javascript', 'linesOfJavaScript'],
+  ['lines of json', 'linesOfJson'],
+  ['lines of other', 'linesOfOther'],
+  ['nodes', 'nodes'],
+  ['identifiers', 'identifiers'],
+  ['symbols', 'symbols'],
+  ['types', 'types'],
+  ['instantiations', 'instantiations'],
+  ['memory used', 'memoryUsed'],
+  ['assignability cache size', 'assignabilityCacheSize'],
+  ['identity cache size', 'identityCacheSize'],
+  ['subtype cache size', 'subtypeCacheSize'],
+  ['strict subtype cache size', 'strictSubtypeCacheSize'],
+  ['i/o read time', 'ioReadTime'],
+  ['i/o write time', 'ioWriteTime'],
+  ['parse time', 'parseTime'],
+  ['resolvemodule time', 'resolveModuleTime'],
+  ['resolvetypereference time', 'resolveTypeReferenceTime'],
+  ['resolvelibrary time', 'resolveLibraryTime'],
+  ['program time', 'programTime'],
+  ['bind time', 'bindTime'],
+  ['check time', 'checkTime'],
+  ['transformtime time', 'transformTime'],
+  ['commenttime time', 'commentTime'],
+  ['printtime time', 'printTime'],
+  ['emit time', 'emitTime'],
+  ['total time', 'totalTime'],
+])
+
+const valuePattern = /^([+-]?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?)\s*([a-z]+)?$/i
+
+export function parseExtendedDiagnostics(text: string): ExtendedDiagnosticsSummary | undefined {
+  const metrics: Record<string, ExtendedDiagnosticMetric> = {}
+
+  for (const line of text.split(/\r?\n/)) {
+    const separatorIndex = line.indexOf(':')
+    if (separatorIndex === -1)
+      continue
+
+    const label = line.slice(0, separatorIndex).trim().toLowerCase()
+    const key = metricKeysByLabel.get(label)
+    if (!key)
+      continue
+
+    const metric = parseMetricValue(line.slice(separatorIndex + 1))
+    if (!metric)
+      continue
+
+    metrics[key] = metric
+  }
+
+  if (Object.keys(metrics).length === 0)
+    return undefined
+
+  const summary: ExtendedDiagnosticsSummary = { metrics }
+  setSummaryNumber(summary, 'files', metrics.files)
+  setSummaryNumber(summary, 'identifiers', metrics.identifiers)
+  setSummaryNumber(summary, 'symbols', metrics.symbols)
+  setSummaryNumber(summary, 'types', metrics.types)
+  setSummaryNumber(summary, 'instantiations', metrics.instantiations)
+  setSummaryNumber(summary, 'memoryUsedKb', metrics.memoryUsed)
+  setSummaryNumber(summary, 'parseTimeMs', metrics.parseTime)
+  setSummaryNumber(summary, 'bindTimeMs', metrics.bindTime)
+  setSummaryNumber(summary, 'checkTimeMs', metrics.checkTime)
+  setSummaryNumber(summary, 'emitTimeMs', metrics.emitTime)
+  setSummaryNumber(summary, 'totalTimeMs', metrics.totalTime)
+
+  const lines = {
+    total: metrics.lines?.value,
+    library: metrics.linesOfLibrary?.value,
+    definitions: metrics.linesOfDefinitions?.value,
+    typescript: metrics.linesOfTypeScript?.value,
+    javascript: metrics.linesOfJavaScript?.value,
+    json: metrics.linesOfJson?.value,
+    other: metrics.linesOfOther?.value,
+  }
+  if (Object.values(lines).some(value => value !== undefined))
+    summary.lines = lines
+
+  return summary
+}
+
+function parseMetricValue(rawValue: string): ExtendedDiagnosticMetric | undefined {
+  const raw = rawValue.trim()
+  const match = valuePattern.exec(raw)
+  if (!match)
+    return undefined
+
+  const value = Number(match[1].replace(/,/g, ''))
+  if (!Number.isFinite(value))
+    return undefined
+
+  const rawUnit = match[2]?.toLowerCase()
+  if (rawUnit === 's') {
+    return {
+      value: normalizeNumber(value * 1000),
+      unit: 'ms',
+      raw,
+    }
+  }
+
+  if (rawUnit === 'ms') {
+    return {
+      value: normalizeNumber(value),
+      unit: 'ms',
+      raw,
+    }
+  }
+
+  if (rawUnit === 'k' || rawUnit === 'kb' || rawUnit === 'kib') {
+    return {
+      value: normalizeNumber(value),
+      unit: 'kb',
+      raw,
+    }
+  }
+
+  if (rawUnit === 'm' || rawUnit === 'mb' || rawUnit === 'mib') {
+    return {
+      value: normalizeNumber(value * 1024),
+      unit: 'kb',
+      raw,
+    }
+  }
+
+  return {
+    value: normalizeNumber(value),
+    unit: 'count',
+    raw,
+  }
+}
+
+function normalizeNumber(value: number) {
+  return Number(value.toFixed(3))
+}
+
+function setSummaryNumber(
+  summary: ExtendedDiagnosticsSummary,
+  key: Exclude<keyof ExtendedDiagnosticsSummary, 'lines' | 'metrics'>,
+  metric: ExtendedDiagnosticMetric | undefined,
+) {
+  if (metric)
+    summary[key] = metric.value
+}

--- a/src/traceRunMetrics.ts
+++ b/src/traceRunMetrics.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'node:buffer'
 import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+import { type ExtendedDiagnosticsSummary, parseExtendedDiagnostics } from './extendedDiagnostics'
 
 export const TRACE_RUN_METRICS_FILE = 'metrics.json'
 
@@ -49,6 +50,7 @@ export interface TraceRunMetrics {
   exitCode: number | null
   stdout: OutputSummary
   stderr: OutputSummary
+  extendedDiagnostics?: ExtendedDiagnosticsSummary
   traceJsonFiles: TraceJsonFile[]
   parse: TraceParseSummary
 }
@@ -67,6 +69,8 @@ export function summarizeOutput(text: string, limit = DEFAULT_OUTPUT_LIMIT): Out
 }
 
 export function buildTraceRunMetrics(input: TraceRunMetricsInput): TraceRunMetrics {
+  const extendedDiagnostics = parseExtendedDiagnostics(`${input.stdout}\n${input.stderr}`)
+
   return {
     version: 1,
     command: input.command,
@@ -78,6 +82,7 @@ export function buildTraceRunMetrics(input: TraceRunMetricsInput): TraceRunMetri
     exitCode: input.exitCode,
     stdout: summarizeOutput(input.stdout),
     stderr: summarizeOutput(input.stderr),
+    ...(extendedDiagnostics ? { extendedDiagnostics } : {}),
     traceJsonFiles: input.traceJsonFiles,
     parse: input.parseSummary,
   }

--- a/src/traceRunMetrics.ts
+++ b/src/traceRunMetrics.ts
@@ -1,0 +1,130 @@
+import { Buffer } from 'node:buffer'
+import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+export const TRACE_RUN_METRICS_FILE = 'metrics.json'
+
+const DEFAULT_OUTPUT_LIMIT = 16_000
+
+export interface OutputSummary {
+  bytes: number
+  truncated: boolean
+  text: string
+}
+
+export interface TraceJsonFile {
+  fileName: string
+  bytes: number
+}
+
+export type TraceParseStatus = 'missing' | 'ok' | 'warning' | 'error'
+
+export interface TraceParseSummary {
+  status: TraceParseStatus
+  topLevelWarning?: string
+}
+
+export interface TraceRunMetricsInput {
+  command: string
+  cwd: string
+  traceDir: string
+  startedAt: string
+  endedAt: string
+  wallTimeMs: number
+  exitCode: number | null
+  stdout: string
+  stderr: string
+  traceJsonFiles: TraceJsonFile[]
+  parseSummary: TraceParseSummary
+}
+
+export interface TraceRunMetrics {
+  version: 1
+  command: string
+  cwd: string
+  traceDir: string
+  startedAt: string
+  endedAt: string
+  wallTimeMs: number
+  exitCode: number | null
+  stdout: OutputSummary
+  stderr: OutputSummary
+  traceJsonFiles: TraceJsonFile[]
+  parse: TraceParseSummary
+}
+
+export function summarizeOutput(text: string, limit = DEFAULT_OUTPUT_LIMIT): OutputSummary {
+  const bytes = Buffer.byteLength(text)
+  if (text.length <= limit) {
+    return { bytes, truncated: false, text }
+  }
+
+  return {
+    bytes,
+    truncated: true,
+    text: text.slice(text.length - limit),
+  }
+}
+
+export function buildTraceRunMetrics(input: TraceRunMetricsInput): TraceRunMetrics {
+  return {
+    version: 1,
+    command: input.command,
+    cwd: input.cwd,
+    traceDir: input.traceDir,
+    startedAt: input.startedAt,
+    endedAt: input.endedAt,
+    wallTimeMs: input.wallTimeMs,
+    exitCode: input.exitCode,
+    stdout: summarizeOutput(input.stdout),
+    stderr: summarizeOutput(input.stderr),
+    traceJsonFiles: input.traceJsonFiles,
+    parse: input.parseSummary,
+  }
+}
+
+export async function discoverTraceJsonFiles(traceDir: string): Promise<TraceJsonFile[]> {
+  const entries = await readdir(traceDir, { withFileTypes: true })
+  const files = await Promise.all(
+    entries
+      .filter(entry => entry.isFile() && entry.name.endsWith('.json') && entry.name !== TRACE_RUN_METRICS_FILE)
+      .map(async (entry) => {
+        const fileStat = await stat(join(traceDir, entry.name))
+        return {
+          fileName: entry.name,
+          bytes: fileStat.size,
+        }
+      }),
+  )
+
+  return files.sort((a, b) => a.fileName.localeCompare(b.fileName))
+}
+
+export async function summarizeTraceParse(traceDir: string, traceJsonFiles: TraceJsonFile[]): Promise<TraceParseSummary> {
+  if (traceJsonFiles.length === 0) {
+    return {
+      status: 'missing',
+      topLevelWarning: 'No trace JSON files were found.',
+    }
+  }
+
+  for (const file of traceJsonFiles) {
+    try {
+      JSON.parse(await readFile(join(traceDir, file.fileName), 'utf8'))
+    }
+    catch (error) {
+      return {
+        status: 'error',
+        topLevelWarning: `${file.fileName}: ${error instanceof Error ? error.message : `${error}`}`,
+      }
+    }
+  }
+
+  return { status: 'ok' }
+}
+
+export async function writeTraceRunMetrics(traceDir: string, metrics: TraceRunMetrics): Promise<void> {
+  const fileName = join(traceDir, TRACE_RUN_METRICS_FILE)
+  await mkdir(dirname(fileName), { recursive: true })
+  await writeFile(fileName, `${JSON.stringify(metrics, null, 2)}\n`, 'utf8')
+}

--- a/test/extendedDiagnostics.test.ts
+++ b/test/extendedDiagnostics.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { parseExtendedDiagnostics } from '../src/extendedDiagnostics'
+
+describe('extended diagnostics parser', () => {
+  it('parses tsc --extendedDiagnostics counters, memory, and timings', () => {
+    const diagnostics = parseExtendedDiagnostics(`
+src/index.ts(1,1): error TS2322: Type 'string' is not assignable to type 'number'.
+Files:                         128
+Lines of Library:           38,470
+Lines of Definitions:        1,234
+Lines of TypeScript:           456
+Lines of JavaScript:             7
+Lines of JSON:                   3
+Lines of Other:                  2
+Identifiers:                52,001
+Symbols:                    39,120
+Types:                      14,567
+Instantiations:              8,901
+Memory used:               174356K
+Parse time:                  0.36s
+Bind time:                   0.10s
+Check time:                  1.25s
+Emit time:                   0.00s
+Total time:                  1.71s
+`)
+
+    expect(diagnostics).toMatchObject({
+      files: 128,
+      lines: {
+        library: 38470,
+        definitions: 1234,
+        typescript: 456,
+        javascript: 7,
+        json: 3,
+        other: 2,
+      },
+      identifiers: 52001,
+      symbols: 39120,
+      types: 14567,
+      instantiations: 8901,
+      memoryUsedKb: 174356,
+      parseTimeMs: 360,
+      bindTimeMs: 100,
+      checkTimeMs: 1250,
+      emitTimeMs: 0,
+      totalTimeMs: 1710,
+      metrics: {
+        memoryUsed: { value: 174356, unit: 'kb', raw: '174356K' },
+        checkTime: { value: 1250, unit: 'ms', raw: '1.25s' },
+      },
+    })
+  })
+
+  it('keeps supplemental extended diagnostics in the metrics map', () => {
+    const diagnostics = parseExtendedDiagnostics(`
+Assignability cache size:       99
+I/O Read time:                0.01s
+ResolveModule time:           0.02s
+printTime time:               0.03s
+`)
+
+    expect(diagnostics?.metrics).toMatchObject({
+      assignabilityCacheSize: { value: 99, unit: 'count', raw: '99' },
+      ioReadTime: { value: 10, unit: 'ms', raw: '0.01s' },
+      resolveModuleTime: { value: 20, unit: 'ms', raw: '0.02s' },
+      printTime: { value: 30, unit: 'ms', raw: '0.03s' },
+    })
+  })
+
+  it('returns undefined when no extended diagnostics are present', () => {
+    expect(parseExtendedDiagnostics('error TS2307: Cannot find module')).toBeUndefined()
+  })
+})

--- a/test/traceRunMetrics.test.ts
+++ b/test/traceRunMetrics.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  TRACE_RUN_METRICS_FILE,
+  buildTraceRunMetrics,
+  discoverTraceJsonFiles,
+  summarizeOutput,
+  summarizeTraceParse,
+  writeTraceRunMetrics,
+} from '../src/traceRunMetrics'
+
+const tempDirs: string[] = []
+
+async function makeTempDir() {
+  const dir = await mkdtemp(join(tmpdir(), 'tsperf-trace-metrics-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+})
+
+describe('trace run metrics', () => {
+  it('summarizes output and keeps the tail when truncated', () => {
+    expect(summarizeOutput('hello', 10)).toEqual({
+      bytes: 5,
+      truncated: false,
+      text: 'hello',
+    })
+
+    expect(summarizeOutput('0123456789', 4)).toEqual({
+      bytes: 10,
+      truncated: true,
+      text: '6789',
+    })
+  })
+
+  it('discovers trace JSON files without including metrics.json', async () => {
+    const traceDir = await makeTempDir()
+    await writeFile(join(traceDir, 'types.json'), '[]')
+    await writeFile(join(traceDir, 'trace.json'), '[]')
+    await writeFile(join(traceDir, TRACE_RUN_METRICS_FILE), '{}')
+    await writeFile(join(traceDir, 'notes.txt'), 'ignored')
+
+    await expect(discoverTraceJsonFiles(traceDir)).resolves.toEqual([
+      { fileName: 'trace.json', bytes: 2 },
+      { fileName: 'types.json', bytes: 2 },
+    ])
+  })
+
+  it('reports parse status for missing, valid, and invalid trace files', async () => {
+    const traceDir = await makeTempDir()
+
+    await expect(summarizeTraceParse(traceDir, [])).resolves.toEqual({
+      status: 'missing',
+      topLevelWarning: 'No trace JSON files were found.',
+    })
+
+    await writeFile(join(traceDir, 'trace.json'), '[]')
+    const files = await discoverTraceJsonFiles(traceDir)
+    await expect(summarizeTraceParse(traceDir, files)).resolves.toEqual({ status: 'ok' })
+
+    await writeFile(join(traceDir, 'types.json'), '{')
+    const invalidFiles = await discoverTraceJsonFiles(traceDir)
+    const invalidSummary = await summarizeTraceParse(traceDir, invalidFiles)
+    expect(invalidSummary.status).toBe('error')
+    expect(invalidSummary.topLevelWarning).toContain('types.json:')
+  })
+
+  it('builds and writes a stable metrics artifact', async () => {
+    const traceDir = await makeTempDir()
+    const metrics = buildTraceRunMetrics({
+      command: 'npx tsc --noEmit --generateTrace trace',
+      cwd: '/repo',
+      traceDir,
+      startedAt: '2026-05-18T00:00:00.000Z',
+      endedAt: '2026-05-18T00:00:01.250Z',
+      wallTimeMs: 1250,
+      exitCode: 0,
+      stdout: 'ok',
+      stderr: '',
+      traceJsonFiles: [{ fileName: 'trace.json', bytes: 2 }],
+      parseSummary: { status: 'ok' },
+    })
+
+    expect(metrics).toMatchObject({
+      version: 1,
+      command: 'npx tsc --noEmit --generateTrace trace',
+      cwd: '/repo',
+      traceDir,
+      wallTimeMs: 1250,
+      exitCode: 0,
+      stdout: { bytes: 2, truncated: false, text: 'ok' },
+      stderr: { bytes: 0, truncated: false, text: '' },
+      traceJsonFiles: [{ fileName: 'trace.json', bytes: 2 }],
+      parse: { status: 'ok' },
+    })
+
+    await writeTraceRunMetrics(traceDir, metrics)
+    await expect(readFile(join(traceDir, TRACE_RUN_METRICS_FILE), 'utf8'))
+      .resolves.toBe(`${JSON.stringify(metrics, null, 2)}\n`)
+  })
+})

--- a/test/traceRunMetrics.test.ts
+++ b/test/traceRunMetrics.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -72,6 +73,13 @@ describe('trace run metrics', () => {
 
   it('builds and writes a stable metrics artifact', async () => {
     const traceDir = await makeTempDir()
+    const stdout = `Files:                         8
+Types:                        83
+Instantiations:                0
+Memory used:              48895K
+Check time:                0.01s
+Total time:                0.59s
+`
     const metrics = buildTraceRunMetrics({
       command: 'npx tsc --noEmit --generateTrace trace',
       cwd: '/repo',
@@ -80,7 +88,7 @@ describe('trace run metrics', () => {
       endedAt: '2026-05-18T00:00:01.250Z',
       wallTimeMs: 1250,
       exitCode: 0,
-      stdout: 'ok',
+      stdout,
       stderr: '',
       traceJsonFiles: [{ fileName: 'trace.json', bytes: 2 }],
       parseSummary: { status: 'ok' },
@@ -93,11 +101,25 @@ describe('trace run metrics', () => {
       traceDir,
       wallTimeMs: 1250,
       exitCode: 0,
-      stdout: { bytes: 2, truncated: false, text: 'ok' },
+      stdout: {
+        bytes: Buffer.byteLength(stdout),
+        truncated: false,
+        text: stdout,
+      },
       stderr: { bytes: 0, truncated: false, text: '' },
+      extendedDiagnostics: {
+        files: 8,
+        types: 83,
+        instantiations: 0,
+        memoryUsedKb: 48895,
+        checkTimeMs: 10,
+        totalTimeMs: 590,
+      },
       traceJsonFiles: [{ fileName: 'trace.json', bytes: 2 }],
       parse: { status: 'ok' },
     })
+
+    expect(metrics.extendedDiagnostics?.metrics.checkTime).toEqual({ value: 10, unit: 'ms', raw: '0.01s' })
 
     await writeTraceRunMetrics(traceDir, metrics)
     await expect(readFile(join(traceDir, TRACE_RUN_METRICS_FILE), 'utf8'))


### PR DESCRIPTION
## Summary

- parse `tsc --extendedDiagnostics` output into structured counters, memory, and timing values
- attach the parsed summary to the trace-run `metrics.json` artifact
- cover common counters such as Types, Instantiations, Memory used, Parse/Bind/Check/Emit/Total time

## Stacked PR note

This is stacked on #70 (`metrics.json` artifact). Until #70 lands, this draft includes that artifact base commit plus the extended-diagnostics commit.

## Validation

- `pnpm exec vitest run test/extendedDiagnostics.test.ts test/traceRunMetrics.test.ts`
- `pnpm typecheck`

## Scope

Draft PR for compiler diagnostics parsing and metrics integration only. It avoids current visualization, depth-limit, Windows cwd/drive, virtualization, and trace-server work.