### PR TITLE
feat: compare trace run metrics

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,6 +13,7 @@ import { addTraceFile, getWorkspacePath, openTerminal, openTraceDirectoryExterna
 import { addTraceDiagnostics, clearTaceDiagnostics } from './traceDiagnostics'
 import { setStatusBarState } from './statusBar'
 import { afterWatches, projectPath, saveName, state, traceFiles, traceRunning } from './appState'
+import { TRACE_RUN_METRICS_FILE, buildTraceRunMetrics, discoverTraceJsonFiles, summarizeTraceParse, writeTraceRunMetrics } from './traceRunMetrics'
 
 const readdir = promisify(readdirC)
 
@@ -148,21 +149,50 @@ async function runTrace(args?: unknown[]) {
     setStatusBarState('traceError', false)
 
     log(`shell: ${process.env.SHELL}`)
+    const startedAtMs = Date.now()
+    const startedAt = new Date(startedAtMs).toISOString()
     const cmdProcess = spawn(fullCmd, [], { cwd: newProjectPath, shell: process.env.SHELL })
 
     let err = ''
+    let out = ''
     cmdProcess.stderr.on('data', data => err += data.toString())
 
-    cmdProcess.stdout.on('data', data => log(data.toString()))
+    cmdProcess.stdout.on('data', (data) => {
+      const chunk = data.toString()
+      out += chunk
+      log(chunk)
+    })
 
-    cmdProcess.on('error', (error) => {
+    let metricsWritten = false
+    async function writeMetricsOnce(exitCode: number | null) {
+      if (metricsWritten)
+        return
+
+      metricsWritten = true
+      await writeRunMetrics({
+        command: fullCmd,
+        cwd: newProjectPath,
+        traceDir,
+        startedAt,
+        startedAtMs,
+        exitCode,
+        stdout: out,
+        stderr: err,
+      })
+    }
+
+    cmdProcess.on('error', async (error) => {
+      traceRunning.value = false
+      setStatusBarState('traceError', true)
       vscode.window.showErrorMessage(error.message)
+      await writeMetricsOnce(null)
     })
 
     cmdProcess.on('exit', async (code) => {
       log('---- trace stderr -----')
       log(err)
       traceRunning.value = false
+      await writeMetricsOnce(code)
       if (code) {
         setStatusBarState('traceError', true)
         vscode.window.showErrorMessage('error running trace')
@@ -174,6 +204,41 @@ async function runTrace(args?: unknown[]) {
   })
 }
 
+async function writeRunMetrics(input: {
+  command: string
+  cwd: string
+  traceDir: string
+  startedAt: string
+  startedAtMs: number
+  exitCode: number | null
+  stdout: string
+  stderr: string
+}) {
+  try {
+    const traceJsonFiles = existsSync(input.traceDir) ? await discoverTraceJsonFiles(input.traceDir) : []
+    const parseSummary = existsSync(input.traceDir)
+      ? await summarizeTraceParse(input.traceDir, traceJsonFiles)
+      : { status: 'missing' as const, topLevelWarning: 'Trace directory was not created.' }
+
+    await writeTraceRunMetrics(input.traceDir, buildTraceRunMetrics({
+      command: input.command,
+      cwd: input.cwd,
+      traceDir: input.traceDir,
+      startedAt: input.startedAt,
+      endedAt: new Date().toISOString(),
+      wallTimeMs: Date.now() - input.startedAtMs,
+      exitCode: input.exitCode,
+      stdout: input.stdout,
+      stderr: input.stderr,
+      traceJsonFiles,
+      parseSummary,
+    }))
+  }
+  catch (error) {
+    log(`error writing trace metrics: ${error instanceof Error ? error.message : `${error}`}`)
+  }
+}
+
 export async function sendTraceDir(traceDir: string) {
   try {
     if (!existsSync(traceDir)) {
@@ -182,6 +247,9 @@ export async function sendTraceDir(traceDir: string) {
 
     const fileNames = await readdir(traceDir)
     for (const fileName of fileNames) {
+      if (fileName === TRACE_RUN_METRICS_FILE)
+        continue
+
       sendTrace(traceDir, fileName)
     }
   }

--- a/src/traceRunComparison.ts
+++ b/src/traceRunComparison.ts
@@ -1,0 +1,91 @@
+import type { OutputSummary, TraceParseStatus, TraceRunMetrics } from './traceRunMetrics'
+
+export interface NumberDelta {
+  before: number
+  after: number
+  delta: number
+}
+
+export interface NullableNumberChange {
+  before: number | null
+  after: number | null
+  changed: boolean
+}
+
+export interface BooleanChange {
+  before: boolean
+  after: boolean
+  changed: boolean
+}
+
+export interface StringChange<T extends string> {
+  before: T
+  after: T
+  changed: boolean
+}
+
+export interface OutputSummaryComparison {
+  bytes: NumberDelta
+  summaryLength: NumberDelta
+  truncated: BooleanChange
+}
+
+export interface TraceRunMetricsComparison {
+  wallTimeMs: NumberDelta
+  exitCode: NullableNumberChange
+  traceFileCount: NumberDelta
+  parseStatus: StringChange<TraceParseStatus>
+  stdout: OutputSummaryComparison
+  stderr: OutputSummaryComparison
+}
+
+function compareNumbers(before: number, after: number): NumberDelta {
+  return {
+    before,
+    after,
+    delta: after - before,
+  }
+}
+
+function compareNullableNumbers(before: number | null, after: number | null): NullableNumberChange {
+  return {
+    before,
+    after,
+    changed: before !== after,
+  }
+}
+
+function compareBooleans(before: boolean, after: boolean): BooleanChange {
+  return {
+    before,
+    after,
+    changed: before !== after,
+  }
+}
+
+function compareStrings<T extends string>(before: T, after: T): StringChange<T> {
+  return {
+    before,
+    after,
+    changed: before !== after,
+  }
+}
+
+function compareOutputSummary(before: OutputSummary, after: OutputSummary): OutputSummaryComparison {
+  return {
+    bytes: compareNumbers(before.bytes, after.bytes),
+    summaryLength: compareNumbers(before.text.length, after.text.length),
+    truncated: compareBooleans(before.truncated, after.truncated),
+  }
+}
+
+export function compareTraceRunMetrics(before: TraceRunMetrics, after: TraceRunMetrics): TraceRunMetricsComparison {
+  return {
+    wallTimeMs: compareNumbers(before.wallTimeMs, after.wallTimeMs),
+    exitCode: compareNullableNumbers(before.exitCode, after.exitCode),
+    traceFileCount: compareNumbers(before.traceJsonFiles.length, after.traceJsonFiles.length),
+    parseStatus: compareStrings(before.parse.status, after.parse.status),
+    stdout: compareOutputSummary(before.stdout, after.stdout),
+    stderr: compareOutputSummary(before.stderr, after.stderr),
+  }
+}

--- a/src/traceRunMetrics.ts
+++ b/src/traceRunMetrics.ts
@@ -1,0 +1,130 @@
+import { Buffer } from 'node:buffer'
+import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+export const TRACE_RUN_METRICS_FILE = 'metrics.json'
+
+const DEFAULT_OUTPUT_LIMIT = 16_000
+
+export interface OutputSummary {
+  bytes: number
+  truncated: boolean
+  text: string
+}
+
+export interface TraceJsonFile {
+  fileName: string
+  bytes: number
+}
+
+export type TraceParseStatus = 'missing' | 'ok' | 'warning' | 'error'
+
+export interface TraceParseSummary {
+  status: TraceParseStatus
+  topLevelWarning?: string
+}
+
+export interface TraceRunMetricsInput {
+  command: string
+  cwd: string
+  traceDir: string
+  startedAt: string
+  endedAt: string
+  wallTimeMs: number
+  exitCode: number | null
+  stdout: string
+  stderr: string
+  traceJsonFiles: TraceJsonFile[]
+  parseSummary: TraceParseSummary
+}
+
+export interface TraceRunMetrics {
+  version: 1
+  command: string
+  cwd: string
+  traceDir: string
+  startedAt: string
+  endedAt: string
+  wallTimeMs: number
+  exitCode: number | null
+  stdout: OutputSummary
+  stderr: OutputSummary
+  traceJsonFiles: TraceJsonFile[]
+  parse: TraceParseSummary
+}
+
+export function summarizeOutput(text: string, limit = DEFAULT_OUTPUT_LIMIT): OutputSummary {
+  const bytes = Buffer.byteLength(text)
+  if (text.length <= limit) {
+    return { bytes, truncated: false, text }
+  }
+
+  return {
+    bytes,
+    truncated: true,
+    text: text.slice(text.length - limit),
+  }
+}
+
+export function buildTraceRunMetrics(input: TraceRunMetricsInput): TraceRunMetrics {
+  return {
+    version: 1,
+    command: input.command,
+    cwd: input.cwd,
+    traceDir: input.traceDir,
+    startedAt: input.startedAt,
+    endedAt: input.endedAt,
+    wallTimeMs: input.wallTimeMs,
+    exitCode: input.exitCode,
+    stdout: summarizeOutput(input.stdout),
+    stderr: summarizeOutput(input.stderr),
+    traceJsonFiles: input.traceJsonFiles,
+    parse: input.parseSummary,
+  }
+}
+
+export async function discoverTraceJsonFiles(traceDir: string): Promise<TraceJsonFile[]> {
+  const entries = await readdir(traceDir, { withFileTypes: true })
+  const files = await Promise.all(
+    entries
+      .filter(entry => entry.isFile() && entry.name.endsWith('.json') && entry.name !== TRACE_RUN_METRICS_FILE)
+      .map(async (entry) => {
+        const fileStat = await stat(join(traceDir, entry.name))
+        return {
+          fileName: entry.name,
+          bytes: fileStat.size,
+        }
+      }),
+  )
+
+  return files.sort((a, b) => a.fileName.localeCompare(b.fileName))
+}
+
+export async function summarizeTraceParse(traceDir: string, traceJsonFiles: TraceJsonFile[]): Promise<TraceParseSummary> {
+  if (traceJsonFiles.length === 0) {
+    return {
+      status: 'missing',
+      topLevelWarning: 'No trace JSON files were found.',
+    }
+  }
+
+  for (const file of traceJsonFiles) {
+    try {
+      JSON.parse(await readFile(join(traceDir, file.fileName), 'utf8'))
+    }
+    catch (error) {
+      return {
+        status: 'error',
+        topLevelWarning: `${file.fileName}: ${error instanceof Error ? error.message : `${error}`}`,
+      }
+    }
+  }
+
+  return { status: 'ok' }
+}
+
+export async function writeTraceRunMetrics(traceDir: string, metrics: TraceRunMetrics): Promise<void> {
+  const fileName = join(traceDir, TRACE_RUN_METRICS_FILE)
+  await mkdir(dirname(fileName), { recursive: true })
+  await writeFile(fileName, `${JSON.stringify(metrics, null, 2)}\n`, 'utf8')
+}

--- a/test/traceRunComparison.test.ts
+++ b/test/traceRunComparison.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { compareTraceRunMetrics } from '../src/traceRunComparison'
+import type { TraceRunMetrics } from '../src/traceRunMetrics'
+
+function makeMetrics(overrides: Partial<TraceRunMetrics> = {}): TraceRunMetrics {
+  return {
+    version: 1,
+    command: 'npx tsc --noEmit --generateTrace trace',
+    cwd: '/repo',
+    traceDir: '/repo/trace',
+    startedAt: '2026-05-18T00:00:00.000Z',
+    endedAt: '2026-05-18T00:00:01.000Z',
+    wallTimeMs: 1000,
+    exitCode: 0,
+    stdout: { bytes: 2, truncated: false, text: 'ok' },
+    stderr: { bytes: 0, truncated: false, text: '' },
+    traceJsonFiles: [{ fileName: 'trace.json', bytes: 2 }],
+    parse: { status: 'ok' },
+    ...overrides,
+  }
+}
+
+describe('trace run comparison', () => {
+  it('compares core metrics between two run artifacts', () => {
+    const before = makeMetrics({
+      wallTimeMs: 1200,
+      exitCode: 0,
+      stdout: { bytes: 12, truncated: false, text: 'before run' },
+      stderr: { bytes: 0, truncated: false, text: '' },
+      traceJsonFiles: [{ fileName: 'trace.json', bytes: 2 }],
+      parse: { status: 'ok' },
+    })
+    const after = makeMetrics({
+      wallTimeMs: 1575,
+      exitCode: 2,
+      stdout: { bytes: 24, truncated: true, text: 'candidate run tail' },
+      stderr: { bytes: 19, truncated: false, text: 'type errors emitted' },
+      traceJsonFiles: [
+        { fileName: 'trace.json', bytes: 2 },
+        { fileName: 'types.json', bytes: 3 },
+        { fileName: 'symbols.json', bytes: 4 },
+      ],
+      parse: { status: 'error', topLevelWarning: 'trace.json: invalid JSON' },
+    })
+
+    expect(compareTraceRunMetrics(before, after)).toEqual({
+      wallTimeMs: { before: 1200, after: 1575, delta: 375 },
+      exitCode: { before: 0, after: 2, changed: true },
+      traceFileCount: { before: 1, after: 3, delta: 2 },
+      parseStatus: { before: 'ok', after: 'error', changed: true },
+      stdout: {
+        bytes: { before: 12, after: 24, delta: 12 },
+        summaryLength: { before: 10, after: 18, delta: 8 },
+        truncated: { before: false, after: true, changed: true },
+      },
+      stderr: {
+        bytes: { before: 0, after: 19, delta: 19 },
+        summaryLength: { before: 0, after: 19, delta: 19 },
+        truncated: { before: false, after: false, changed: false },
+      },
+    })
+  })
+
+  it('reports negative deltas and unchanged nullable/status fields', () => {
+    const before = makeMetrics({
+      wallTimeMs: 1000,
+      exitCode: null,
+      stdout: { bytes: 100, truncated: true, text: 'long stdout tail' },
+      stderr: { bytes: 40, truncated: false, text: 'warnings' },
+      traceJsonFiles: [
+        { fileName: 'trace.json', bytes: 2 },
+        { fileName: 'types.json', bytes: 3 },
+      ],
+      parse: { status: 'warning', topLevelWarning: 'top-level trace event was not an array' },
+    })
+    const after = makeMetrics({
+      wallTimeMs: 850,
+      exitCode: null,
+      stdout: { bytes: 20, truncated: false, text: 'short' },
+      stderr: { bytes: 0, truncated: false, text: '' },
+      traceJsonFiles: [],
+      parse: { status: 'warning', topLevelWarning: 'top-level trace event was not an array' },
+    })
+
+    const comparison = compareTraceRunMetrics(before, after)
+
+    expect(comparison.wallTimeMs).toEqual({ before: 1000, after: 850, delta: -150 })
+    expect(comparison.exitCode).toEqual({ before: null, after: null, changed: false })
+    expect(comparison.traceFileCount).toEqual({ before: 2, after: 0, delta: -2 })
+    expect(comparison.parseStatus).toEqual({ before: 'warning', after: 'warning', changed: false })
+    expect(comparison.stdout.summaryLength).toEqual({ before: 16, after: 5, delta: -11 })
+    expect(comparison.stderr.summaryLength).toEqual({ before: 8, after: 0, delta: -8 })
+  })
+})

--- a/test/traceRunMetrics.test.ts
+++ b/test/traceRunMetrics.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  TRACE_RUN_METRICS_FILE,
+  buildTraceRunMetrics,
+  discoverTraceJsonFiles,
+  summarizeOutput,
+  summarizeTraceParse,
+  writeTraceRunMetrics,
+} from '../src/traceRunMetrics'
+
+const tempDirs: string[] = []
+
+async function makeTempDir() {
+  const dir = await mkdtemp(join(tmpdir(), 'tsperf-trace-metrics-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+})
+
+describe('trace run metrics', () => {
+  it('summarizes output and keeps the tail when truncated', () => {
+    expect(summarizeOutput('hello', 10)).toEqual({
+      bytes: 5,
+      truncated: false,
+      text: 'hello',
+    })
+
+    expect(summarizeOutput('0123456789', 4)).toEqual({
+      bytes: 10,
+      truncated: true,
+      text: '6789',
+    })
+  })
+
+  it('discovers trace JSON files without including metrics.json', async () => {
+    const traceDir = await makeTempDir()
+    await writeFile(join(traceDir, 'types.json'), '[]')
+    await writeFile(join(traceDir, 'trace.json'), '[]')
+    await writeFile(join(traceDir, TRACE_RUN_METRICS_FILE), '{}')
+    await writeFile(join(traceDir, 'notes.txt'), 'ignored')
+
+    await expect(discoverTraceJsonFiles(traceDir)).resolves.toEqual([
+      { fileName: 'trace.json', bytes: 2 },
+      { fileName: 'types.json', bytes: 2 },
+    ])
+  })
+
+  it('reports parse status for missing, valid, and invalid trace files', async () => {
+    const traceDir = await makeTempDir()
+
+    await expect(summarizeTraceParse(traceDir, [])).resolves.toEqual({
+      status: 'missing',
+      topLevelWarning: 'No trace JSON files were found.',
+    })
+
+    await writeFile(join(traceDir, 'trace.json'), '[]')
+    const files = await discoverTraceJsonFiles(traceDir)
+    await expect(summarizeTraceParse(traceDir, files)).resolves.toEqual({ status: 'ok' })
+
+    await writeFile(join(traceDir, 'types.json'), '{')
+    const invalidFiles = await discoverTraceJsonFiles(traceDir)
+    const invalidSummary = await summarizeTraceParse(traceDir, invalidFiles)
+    expect(invalidSummary.status).toBe('error')
+    expect(invalidSummary.topLevelWarning).toContain('types.json:')
+  })
+
+  it('builds and writes a stable metrics artifact', async () => {
+    const traceDir = await makeTempDir()
+    const metrics = buildTraceRunMetrics({
+      command: 'npx tsc --noEmit --generateTrace trace',
+      cwd: '/repo',
+      traceDir,
+      startedAt: '2026-05-18T00:00:00.000Z',
+      endedAt: '2026-05-18T00:00:01.250Z',
+      wallTimeMs: 1250,
+      exitCode: 0,
+      stdout: 'ok',
+      stderr: '',
+      traceJsonFiles: [{ fileName: 'trace.json', bytes: 2 }],
+      parseSummary: { status: 'ok' },
+    })
+
+    expect(metrics).toMatchObject({
+      version: 1,
+      command: 'npx tsc --noEmit --generateTrace trace',
+      cwd: '/repo',
+      traceDir,
+      wallTimeMs: 1250,
+      exitCode: 0,
+      stdout: { bytes: 2, truncated: false, text: 'ok' },
+      stderr: { bytes: 0, truncated: false, text: '' },
+      traceJsonFiles: [{ fileName: 'trace.json', bytes: 2 }],
+      parse: { status: 'ok' },
+    })
+
+    await writeTraceRunMetrics(traceDir, metrics)
+    await expect(readFile(join(traceDir, TRACE_RUN_METRICS_FILE), 'utf8'))
+      .resolves.toBe(`${JSON.stringify(metrics, null, 2)}\n`)
+  })
+})


### PR DESCRIPTION
## Summary

- add a helper for comparing two trace-run `metrics.json` artifacts
- report wall time, exit code, trace JSON count, parse status, and stdout/stderr summary deltas
- add tests covering positive and negative deltas

## Stacked PR note

This is stacked on #70 (`metrics.json` artifact). Until #70 lands, this draft includes that artifact base commit plus the comparison helper commit.

## Validation

- `pnpm exec vitest run test/traceRunComparison.test.ts test/traceRunMetrics.test.ts`
- `pnpm typecheck`

## Scope

Draft PR for pure comparison plumbing only. It does not touch visualization, depth-limit highlighting, Windows cwd/drive behavior, virtualization, or trace-server work.