### PR TITLE
feat: add active file mini trace command

### DIFF
--- a/package.json
+++ b/package.json
@@ -298,6 +298,11 @@
         "category": "Tracer"
       },
       {
+        "title": "Trace current file",
+        "command": "tsperf.tracer.runTraceActiveFile",
+        "category": "Tracer"
+      },
+      {
         "title": "Send Trace to Trace Viewer",
         "command": "tsperf.tracer.sendTrace",
         "category": "Tracer"

--- a/scripts/generate-contributes.ts
+++ b/scripts/generate-contributes.ts
@@ -49,6 +49,9 @@ const commandRecord: Record<CommandId, Command> = {
       explorerContext: 'resourceFilename =~ /./',
     },
   },
+  'tsperf.tracer.runTraceActiveFile': {
+    title: 'Trace current file',
+  },
   'tsperf.tracer.sendTrace': {
     title: 'Send Trace to Trace Viewer',
     when: {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,6 +13,7 @@ import { addTraceFile, getWorkspacePath, openTerminal, openTraceDirectoryExterna
 import { addTraceDiagnostics, clearTaceDiagnostics } from './traceDiagnostics'
 import { setStatusBarState } from './statusBar'
 import { afterWatches, projectPath, saveName, state, traceFiles, traceRunning } from './appState'
+import { traceSaveNameForFile } from './traceCommand'
 
 const readdir = promisify(readdirC)
 
@@ -21,6 +22,7 @@ const commandHandlers: Record<
   (context: vscode.ExtensionContext) => (...args: any[]) => void
   > = {
     'tsperf.tracer.runTrace': () => (...args: unknown[]) => runTrace(args),
+    'tsperf.tracer.runTraceActiveFile': () => () => runTraceActiveFile(),
     'tsperf.tracer.openInBrowser': (context: vscode.ExtensionContext) => () => prepareWebView(context),
     'tsperf.tracer.gotoTracePosition': (context: vscode.ExtensionContext) => () => gotoTracePosition(context),
     'tsperf.tracer.sendTrace': () => (event: unknown) => {
@@ -34,6 +36,20 @@ const commandHandlers: Record<
     'tsperf.tracer.openTerminal': () => () => openTerminal(),
     'tsperf.tracer.openTraceDirExternal': () => () => openTraceDirectoryExternal(),
   } as const
+
+async function runTraceActiveFile() {
+  const editor = vscode.window.activeTextEditor
+  if (!editor || editor.document.uri.scheme !== 'file') {
+    vscode.window.showWarningMessage('Open a TypeScript file before running a mini trace')
+    return
+  }
+
+  const workspacePath = state.workspacePath.value || getWorkspacePath()
+  await runTrace([], {
+    cwd: workspacePath,
+    saveName: traceSaveNameForFile(workspacePath, editor.document.uri.fsPath),
+  })
+}
 
 async function sendTrace(dirName: string, fileName: string) {
   const fullFileName = join(dirName, fileName)
@@ -97,7 +113,7 @@ function gotoTracePosition(context: vscode.ExtensionContext) {
   showTree('', relativePath, startOffset - (editor.document.getText()[startOffset + 1] === '\n' ? 0 : 1))
 }
 
-async function runTrace(args?: unknown[]) {
+async function runTrace(args?: unknown[], options?: { cwd?: string, saveName?: string }) {
   const workspacePath = state.workspacePath.value
   const { traceCmd } = getCurrentConfig()
 
@@ -114,7 +130,10 @@ async function runTrace(args?: unknown[]) {
     }
   }
 
-  if (dirName) {
+  if (options?.saveName) {
+    saveName.value = options.saveName
+  }
+  else if (dirName) {
     log(`dirName: ${dirName}`)
     saveName.value = relative(workspacePath, dirName)
   }
@@ -128,13 +147,14 @@ async function runTrace(args?: unknown[]) {
       return
     }
 
+    const traceCwd = options?.cwd ?? newDirName ?? workspacePath
     const quotedTraceDir = `'${traceDir}'`
     // eslint-disable-next-line no-template-curly-in-string
-    const fullCmd = `(cd '${newDirName ?? workspacePath}'; ${traceCmd.replace('${traceDir}', quotedTraceDir)})`
+    const fullCmd = `(cd '${traceCwd}'; ${traceCmd.replace('${traceDir}', quotedTraceDir)})`
 
     log(fullCmd)
 
-    const newProjectPath = newDirName ?? projectPath.value
+    const newProjectPath = traceCwd || projectPath.value
     if (!newProjectPath) {
       vscode.window.showErrorMessage('could not get project path from workspace folders')
       return

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,6 +25,7 @@ export const commandIds = [
   'tsperf.tracer.gotoTracePosition',
   'tsperf.tracer.openInBrowser',
   'tsperf.tracer.runTrace',
+  'tsperf.tracer.runTraceActiveFile',
   'tsperf.tracer.sendTrace',
   'tsperf.tracer.openTerminal',
   'tsperf.tracer.openTraceDirExternal',

--- a/src/traceCommand.ts
+++ b/src/traceCommand.ts
@@ -1,0 +1,7 @@
+import { extname, relative } from 'node:path'
+
+export function traceSaveNameForFile(workspacePath: string, filePath: string): string {
+  const relativeFile = relative(workspacePath, filePath)
+  const extension = extname(relativeFile)
+  return extension ? relativeFile.slice(0, -extension.length) : relativeFile
+}

--- a/test/traceCommand.test.ts
+++ b/test/traceCommand.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { traceSaveNameForFile } from '../src/traceCommand'
+
+describe('traceSaveNameForFile', () => {
+  it('uses the workspace-relative file path without extension', () => {
+    expect(traceSaveNameForFile('/repo', '/repo/src/features/example.ts')).toBe('src/features/example')
+  })
+
+  it('preserves files without extensions', () => {
+    expect(traceSaveNameForFile('/repo', '/repo/tsconfig')).toBe('tsconfig')
+  })
+})


### PR DESCRIPTION
## Summary

- add `Tracer: Trace current file` for a focused trace workflow from the active editor
- save the focused run under a workspace-relative path derived from the active file
- keep the existing `Tracer: tsc trace` command behavior intact

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec vitest run test/traceCommand.test.ts`

## Scope

Draft PR for the small mini-trace command path only. It does not touch trace-server work, hot-path visualization, depth-limit highlighting, Windows cwd/drive behavior, or virtualization.