### PR TITLE
fix: choose containing tsconfig for monorepo files

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -6,23 +6,15 @@ import * as vscode from 'vscode'
 import type { FormatDiagnosticsHost } from 'typescript'
 
 import { log } from './logger'
+import { findClosestTsconfig } from './tsconfigSelection'
 
-export async function getTsconfigFile(path: string) {
-  let files = await vscode.workspace.findFiles('**/tsconfig.json', '**​/node_modules/**')
-  files = files.sort((a, b) => b.fsPath.length - a.fsPath.length)
-    .filter(p => !p.fsPath.includes('node_modules'))
+export async function getTsconfigFile(filePath: string) {
+  const files = await vscode.workspace.findFiles('**/tsconfig.json', '**​/node_modules/**')
+  const tsconfigPath = findClosestTsconfig(filePath, files.map(file => file.fsPath))
 
-  log({ path, files })
+  log({ path: filePath, files, tsconfigPath })
 
-  const pathSegments = path.split('/')
-  for (let i = pathSegments.length; i > 0; i--) {
-    const path = pathSegments.slice(0, i).join('/')
-    const tsConfigFile = files.find(file => file.fsPath.startsWith(path))
-    if (tsConfigFile)
-      return tsConfigFile
-  }
-
-  return files[0]
+  return files.find(file => file.fsPath === tsconfigPath) ?? files[0]
 }
 
 const formatDiagnosticsHost: FormatDiagnosticsHost = {

--- a/src/tsconfigSelection.ts
+++ b/src/tsconfigSelection.ts
@@ -1,0 +1,21 @@
+import path from 'node:path'
+
+export function findClosestTsconfig(filePath: string, tsconfigPaths: string[]): string | undefined {
+  const normalizedFilePath = normalizePath(filePath)
+  const candidates = tsconfigPaths
+    .filter(tsconfigPath => !isNodeModulesPath(tsconfigPath))
+    .sort((a, b) => b.length - a.length)
+
+  return candidates.find((tsconfigPath) => {
+    const configDirectory = normalizePath(path.dirname(tsconfigPath))
+    return normalizedFilePath === configDirectory || normalizedFilePath.startsWith(`${configDirectory}/`)
+  }) ?? candidates[0]
+}
+
+function normalizePath(filePath: string) {
+  return filePath.replaceAll('\\', '/').replace(/\/+$/, '')
+}
+
+function isNodeModulesPath(filePath: string) {
+  return normalizePath(filePath).split('/').includes('node_modules')
+}

--- a/test/tsconfigSelection.test.ts
+++ b/test/tsconfigSelection.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { findClosestTsconfig } from '../src/tsconfigSelection'
+
+describe('findClosestTsconfig', () => {
+  it('selects the nearest tsconfig that contains the target file', () => {
+    expect(findClosestTsconfig(
+      '/repo/packages/app/src/index.ts',
+      [
+        '/repo/tsconfig.json',
+        '/repo/packages/app/tsconfig.json',
+      ],
+    )).toBe('/repo/packages/app/tsconfig.json')
+  })
+
+  it('does not select a sibling package tsconfig for a package without one', () => {
+    expect(findClosestTsconfig(
+      '/repo/packages/app-b/src/index.ts',
+      [
+        '/repo/tsconfig.json',
+        '/repo/packages/app-a/tsconfig.json',
+      ],
+    )).toBe('/repo/tsconfig.json')
+  })
+
+  it('ignores node_modules tsconfig files', () => {
+    expect(findClosestTsconfig(
+      '/repo/packages/app/src/index.ts',
+      [
+        '/repo/packages/app/node_modules/some-package/tsconfig.json',
+        '/repo/tsconfig.json',
+      ],
+    )).toBe('/repo/tsconfig.json')
+  })
+
+  it('handles Windows-style paths', () => {
+    expect(findClosestTsconfig(
+      'C:\\repo\\packages\\app\\src\\index.ts',
+      [
+        'C:\\repo\\tsconfig.json',
+        'C:\\repo\\packages\\app\\tsconfig.json',
+      ],
+    )).toBe('C:\\repo\\packages\\app\\tsconfig.json')
+  })
+})


### PR DESCRIPTION
## Summary

- extract tsconfig selection into a small pure helper
- choose the closest tsconfig whose directory contains the target file
- avoid selecting a sibling package tsconfig when a monorepo package has no local tsconfig
- add coverage for nearest-match, sibling fallback, node_modules, and Windows-style paths

## Why

The previous prefix-based lookup sorted tsconfig files by path length, then returned the first config whose path started with one of the target file's ancestor prefixes. In a monorepo, that can select a sibling package's tsconfig when the target package does not have its own config.

Example:

- target file: `/repo/packages/app-b/src/index.ts`
- configs: `/repo/tsconfig.json`, `/repo/packages/app-a/tsconfig.json`

The sibling `/repo/packages/app-a/tsconfig.json` should not apply to `app-b`; the workspace root config is the safer fallback.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run`
- `pnpm build`