### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/shared/src/messages.ts
+++ b/shared/src/messages.ts
@@ -1,6 +1,6 @@
 import z from 'zod'
 import type { Tree } from '../../src/traceTree'
-import { traceLine, typeLine } from './traceData'
+import { traceLine, traceSeverity, typeLine } from './traceData'
 
 export const ping = z.object({
   message: z.literal('ping'),
@@ -105,6 +105,9 @@ const zodTree: z.ZodType<Tree> = z.lazy(() =>
     childTypeCnt: z.number(),
     childCnt: z.number(),
     typeCnt: z.number(),
+    timeSeverity: traceSeverity.optional(),
+    typeSeverity: traceSeverity.optional(),
+    totalTypeSeverity: traceSeverity.optional(),
   }),
 )
 

--- a/shared/src/traceData.ts
+++ b/shared/src/traceData.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod'
 
+export type TraceSeverity = z.infer<typeof traceSeverity>
+export const traceSeverity = z.enum(['error', 'warning', 'info'])
+
 export type TypeLine = z.infer<typeof typeLine>
 export const typeLine = z.object({
   id: z.number(),
@@ -9,6 +12,7 @@ export const typeLine = z.object({
   ts: z.number(),
   dur: z.number().optional(),
   display: z.string().optional(),
+  timeSeverity: traceSeverity.optional(),
 })
 
 export type TraceLine = z.infer<typeof traceLine>

--- a/src/traceTree.ts
+++ b/src/traceTree.ts
@@ -1,11 +1,23 @@
 import { isAbsolute, join, relative } from 'node:path'
 import type { FileStat } from '../shared/src/messages'
-import type { TraceData, TraceLine, TypeLine } from '../shared/src/traceData'
+import type { TraceData, TraceLine, TraceSeverity, TypeLine } from '../shared/src/traceData'
 import { getWorkspacePath } from './storage'
 import { postMessage } from './webview'
 import { traceFiles } from './appState'
+import { getCurrentConfig } from './configuration'
 
-export interface Tree { id: number, line: TraceLine, children: Tree[], types: TypeLine[], childCnt: number, childTypeCnt: number, typeCnt: number }
+export interface Tree {
+  id: number
+  line: TraceLine
+  children: Tree[]
+  types: TypeLine[]
+  childCnt: number
+  childTypeCnt: number
+  typeCnt: number
+  timeSeverity?: TraceSeverity
+  typeSeverity?: TraceSeverity
+  totalTypeSeverity?: TraceSeverity
+}
 function getRoot(): Tree {
   return {
     id: 0,
@@ -29,6 +41,7 @@ function getRoot(): Tree {
 let treeIndexes: Tree[] = []
 export function toTree(traceData: TraceData, workspacePath: string): Tree {
   const tree: Tree = { ...getRoot() }
+  const config = getCurrentConfig()
   let endTs = Number.MAX_SAFE_INTEGER
   let curr = tree
   let maxDur = 0
@@ -58,6 +71,7 @@ export function toTree(traceData: TraceData, workspacePath: string): Tree {
     }
 
     if ('id' in line) {
+      line.timeSeverity = getThresholdSeverity((line.dur ?? 0) / 1000, config.traceTimeThresholds)
       curr.typeCnt = curr.types.push(line)
     }
     else if (line.dur) {
@@ -71,7 +85,25 @@ export function toTree(traceData: TraceData, workspacePath: string): Tree {
   }
 
   tree.line.dur = maxDur
+  annotateTreeSeverity(tree, config)
   return tree
+}
+
+function getThresholdSeverity(value: number, thresholds: { info: number, warning: number, error: number }): TraceSeverity | undefined {
+  if (thresholds.error >= 0 && value >= thresholds.error)
+    return 'error'
+  if (thresholds.warning >= 0 && value >= thresholds.warning)
+    return 'warning'
+  if (thresholds.info >= 0 && value >= thresholds.info)
+    return 'info'
+  return undefined
+}
+
+function annotateTreeSeverity(tree: Tree, config: ReturnType<typeof getCurrentConfig>) {
+  tree.timeSeverity = getThresholdSeverity((tree.line.dur ?? 0) / 1000, config.traceTimeThresholds)
+  tree.typeSeverity = getThresholdSeverity(tree.typeCnt, config.traceTypeThresholds)
+  tree.totalTypeSeverity = getThresholdSeverity(tree.typeCnt + tree.childTypeCnt, config.traceTotalTypeThresholds)
+  tree.children.forEach(child => annotateTreeSeverity(child, config))
 }
 
 let traceTree: Tree | undefined

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,53 @@
 import { describe, expect, it } from 'vitest'
+import { message } from '../shared/src/messages'
 
-describe('should', () => {
-  it('exported', () => {
-    expect(1).toEqual(1)
+describe('messages', () => {
+  it('preserves trace severity fields on tree messages', () => {
+    const parsed = message.safeParse({
+      message: 'showTree',
+      step: 'add',
+      nodes: [
+        {
+          id: 1,
+          line: {
+            pid: 1,
+            tid: 1,
+            ph: 'X',
+            cat: 'check',
+            ts: 0,
+            name: 'checkSourceFile',
+            dur: 2000,
+          },
+          children: [],
+          types: [
+            {
+              id: 100,
+              ts: 0,
+              dur: 2000,
+              timeSeverity: 'warning',
+            },
+          ],
+          childTypeCnt: 2,
+          childCnt: 0,
+          typeCnt: 1,
+          timeSeverity: 'warning',
+          typeSeverity: 'info',
+          totalTypeSeverity: 'error',
+        },
+      ],
+    })
+
+    expect(parsed.success).toBe(true)
+    if (!parsed.success)
+      return
+
+    expect(parsed.data.message).toBe('showTree')
+    if (parsed.data.message !== 'showTree')
+      return
+
+    expect(parsed.data.nodes[0].timeSeverity).toBe('warning')
+    expect(parsed.data.nodes[0].typeSeverity).toBe('info')
+    expect(parsed.data.nodes[0].totalTypeSeverity).toBe('error')
+    expect(parsed.data.nodes[0].types[0].timeSeverity).toBe('warning')
   })
 })

--- a/ui/components/TreeNode.vue
+++ b/ui/components/TreeNode.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { TraceSeverity } from '../../shared/src/traceData'
 import type { Tree } from '../../src/traceTree'
 import { childrenById, typesById } from '~/src/appState'
 
@@ -8,6 +9,13 @@ const sendMessage = useNuxtApp().$sendMessage
 
 const children = computed(() => childrenById.get(props.tree.id) ?? [])
 const types = computed(() => typesById.get(props.tree.id) ?? [])
+function severityClass(severity: TraceSeverity | undefined) {
+  return {
+    error: 'text-[var(--vscode-errorForeground)]',
+    warning: 'text-[var(--vscode-editorWarning-foreground)]',
+    info: 'text-[var(--vscode-editorInfo-foreground)]',
+  }[severity ?? '']
+}
 
 function fetchChildren() {
   if (children.value.length === 0)
@@ -46,8 +54,8 @@ const insetClass = `border-e min-w-2 border-[var(--vscode-tree-inactiveIndentGui
           <div class="flex flex-row justify-start gap-2 grow text-left">
             <span class="min-w-48">
               {{ tree.line.name }} ({{ tree.childCnt }}):
-            </span><span>
-              {{ Math.round(props.tree.line.dur ?? 0 / 1000) / 1000 }}ms
+            </span><span :class="severityClass(tree.timeSeverity)">
+              {{ Math.round((props.tree.line.dur ?? 0) / 1000) }}ms
             </span>
             <div class="grow opacity-20 hover:opacity-100 h-full">
               <div class="mt-4 border-b border-dashed border-[var(--vscode-tree-indentGuidesStroke)]" />
@@ -67,7 +75,14 @@ const insetClass = `border-e min-w-2 border-[var(--vscode-tree-inactiveIndentGui
           <div class="flex flex-row justify-self-end justify-evenly">
             <UExpand v-if="props.tree.typeCnt > 0" class="min-w-40" @expand="fetchTypes">
               <template #label>
-                <span class="pl-1">{{ `Types: ${props.tree.typeCnt}` }} {{ `${props.tree.childTypeCnt || props.tree.typeCnt ? `/ ${props.tree.childTypeCnt + props.tree.typeCnt}` : ''}` }}</span>
+                <span class="pl-1">
+                  Types:
+                  <span :class="severityClass(props.tree.typeSeverity)">{{ props.tree.typeCnt }}</span>
+                  <template v-if="props.tree.childTypeCnt || props.tree.typeCnt">
+                    /
+                    <span :class="severityClass(props.tree.totalTypeSeverity)">{{ props.tree.childTypeCnt + props.tree.typeCnt }}</span>
+                  </template>
+                </span>
               </template>
               <TypeTable class="relative -left-auto right-auto" :types="types" />
             </UExpand>

--- a/ui/components/TypeLine.vue
+++ b/ui/components/TypeLine.vue
@@ -1,7 +1,14 @@
 <script setup lang="ts">
-import type { TypeLine } from '../../shared/src/traceData'
+import type { TraceSeverity, TypeLine } from '../../shared/src/traceData'
 
 const props = defineProps<{ line: TypeLine }>()
+function severityClass(severity: TraceSeverity | undefined) {
+  return {
+    error: 'text-[var(--vscode-errorForeground)]',
+    warning: 'text-[var(--vscode-editorWarning-foreground)]',
+    info: 'text-[var(--vscode-editorInfo-foreground)]',
+  }[severity ?? '']
+}
 </script>
 
 <template>
@@ -10,7 +17,7 @@ const props = defineProps<{ line: TypeLine }>()
       <div class="col-1">
         ts: {{ Math.round(line.ts ?? 0) }}
       </div>
-      <div class="col-1">
+      <div class="col-1" :class="severityClass(line.timeSeverity)">
         dur: {{ Math.round(line.dur ?? 0) }}
       </div>
       <div class="col-1">


### PR DESCRIPTION
## Summary

Closes #40.

This adds diagnostic-threshold coloring to the trace tree UI:

- colors trace node durations using `traceTimeThresholds`
- colors local type counts using `traceTypeThresholds`
- colors total type counts using `traceTotalTypeThresholds`
- colors type-row durations using `traceTimeThresholds`
- uses VS Code diagnostic theme colors for error/warning/info states

## Notes

Severity is annotated before sending trace data to the webview, as suggested in the issue. The shared message schema now includes the severity fields so they are preserved during Zod parsing on the UI side.

I also fixed the trace tree duration display so the microsecond-to-ms conversion happens before rounding.

A regression test covers `showTree` message parsing so severity fields do not get stripped from tree nodes or type rows.

## Verification

- `corepack pnpm exec vitest run`
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm run generate:contributes`
- `cd srcDev && corepack pnpm exec rollup -c`
- `corepack pnpm exec nuxt build ui`
- `corepack pnpm exec rollup -c`
