### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,6 +13,7 @@ import { addTraceFile, getWorkspacePath, openTerminal, openTraceDirectoryExterna
 import { addTraceDiagnostics, clearTaceDiagnostics } from './traceDiagnostics'
 import { setStatusBarState } from './statusBar'
 import { afterWatches, projectPath, saveName, state, traceFiles, traceRunning } from './appState'
+import { getIncrementalBuildWarning } from './incrementalBuildWarning'
 
 const readdir = promisify(readdirC)
 
@@ -170,8 +171,17 @@ async function runTrace(args?: unknown[]) {
       }
 
       await sendTraceDir(traceDir)
+      const warning = getIncrementalBuildWarning(getTypeScript(), newProjectPath, workspacePath)
+      if (warning)
+        vscode.window.showWarningMessage(warning)
     })
   })
+}
+
+function getTypeScript() {
+  const tsPath = join(dirname(vscode.extensions.getExtension('vscode.typescript-language-features')!.extensionPath), 'node_modules/typescript')
+  // eslint-disable-next-line ts/no-require-imports, ts/no-var-requires
+  return require(tsPath) as typeof import('typescript')
 }
 
 export async function sendTraceDir(traceDir: string) {

--- a/src/incrementalBuildWarning.ts
+++ b/src/incrementalBuildWarning.ts
@@ -1,0 +1,40 @@
+import { existsSync } from 'node:fs'
+import { basename, dirname, join, parse, resolve } from 'node:path'
+import type * as ts from 'typescript'
+
+export function findTsconfig(startPath: string, stopPath?: string) {
+  let dir = resolve(startPath)
+  const root = parse(dir).root
+  const stop = stopPath ? resolve(stopPath) : root
+
+  while (true) {
+    const tsconfigPath = join(dir, 'tsconfig.json')
+    if (existsSync(tsconfigPath))
+      return tsconfigPath
+
+    if (dir === stop || dir === root)
+      return
+
+    dir = dirname(dir)
+  }
+}
+
+export function hasIncrementalBuildEnabled(options: ts.CompilerOptions) {
+  return options.incremental === true || options.composite === true
+}
+
+export function getIncrementalBuildWarning(tsApi: typeof ts, projectPath: string, workspacePath?: string) {
+  const tsconfigPath = findTsconfig(projectPath, workspacePath)
+  if (!tsconfigPath)
+    return
+
+  const configFile = tsApi.readConfigFile(tsconfigPath, tsApi.sys.readFile)
+  if (configFile.error)
+    return
+
+  const parsed = tsApi.parseJsonConfigFileContent(configFile.config, tsApi.sys, dirname(tsconfigPath))
+  if (!hasIncrementalBuildEnabled(parsed.options))
+    return
+
+  return `Trace completed with incremental builds enabled in ${basename(tsconfigPath)}. Incremental caches can skew trace timings; consider disabling "incremental" or "composite" before comparing results.`
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,43 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as ts from 'typescript'
 import { describe, expect, it } from 'vitest'
+import { findTsconfig, getIncrementalBuildWarning, hasIncrementalBuildEnabled } from '../src/incrementalBuildWarning'
 
 describe('should', () => {
   it('exported', () => {
     expect(1).toEqual(1)
+  })
+})
+
+describe('incremental build warnings', () => {
+  it('detects incremental and composite compiler options', () => {
+    expect(hasIncrementalBuildEnabled({ incremental: true })).toBe(true)
+    expect(hasIncrementalBuildEnabled({ composite: true })).toBe(true)
+    expect(hasIncrementalBuildEnabled({ incremental: false, composite: false })).toBe(false)
+  })
+
+  it('finds the nearest tsconfig without walking past the workspace', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'tracer-workspace-'))
+    const project = join(workspace, 'packages', 'app')
+    mkdirSync(project, { recursive: true })
+    writeFileSync(join(workspace, 'tsconfig.json'), '{}')
+
+    expect(findTsconfig(project, workspace)).toBe(join(workspace, 'tsconfig.json'))
+  })
+
+  it('warns when the active tsconfig has incremental builds enabled', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'tracer-workspace-'))
+    writeFileSync(join(workspace, 'tsconfig.json'), JSON.stringify({ compilerOptions: { incremental: true } }))
+
+    expect(getIncrementalBuildWarning(ts, workspace, workspace)).toContain('incremental builds enabled')
+  })
+
+  it('does not warn when incremental builds are disabled', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'tracer-workspace-'))
+    writeFileSync(join(workspace, 'tsconfig.json'), JSON.stringify({ compilerOptions: { incremental: false } }))
+
+    expect(getIncrementalBuildWarning(ts, workspace, workspace)).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

Adds a post-trace warning when the active `tsconfig.json` enables incremental build behavior.

This addresses #21's short-term request: warn users that incremental builds can influence trace output.

## Changes

- Find the `tsconfig.json` used from the traced project directory, walking up to the workspace root.
- Parse the config with TypeScript's config parser so JSONC and inherited compiler options are handled.
- Detect `compilerOptions.incremental` and `compilerOptions.composite`.
- Show a VS Code warning only after a successful trace run.
- Add focused Vitest coverage for config lookup and warning detection.

## Verification

- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm exec vitest run`
- `corepack pnpm run generate:contributes`
- `cd srcDev && corepack pnpm exec rollup -c`
- `corepack pnpm exec nuxt build ui`
- `corepack pnpm exec rollup -c`
