### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,11 +94,17 @@
           "description": "Create diagnostics from trace data",
           "order": 7
         },
+        "tsperf.tracer.useGitBranchSaveName": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use the current Git branch or detached HEAD as the default save name",
+          "order": 8
+        },
         "tsperf.tracer.fileBrowserExecutable": {
           "type": "string",
           "default": "",
           "description": "command to open your preferred file browser. Use the ${traceDir} substitution variable",
-          "order": 8
+          "order": 9
         },
         "tsperf.tracer.traceTimeThresholds": {
           "type": "object",
@@ -125,7 +131,7 @@
             "error": -1
           },
           "description": "todo",
-          "order": 9,
+          "order": 10,
           "markdownDescription": "# Trace Time Thresholds\n\nTrigger diagnostics from trace files when check time in ms exceeds these thresholds.\n\n* -1 will disable diagnostics of that severity\n"
         },
         "tsperf.tracer.traceTypeThresholds": {
@@ -153,7 +159,7 @@
             "error": -1
           },
           "description": "todo",
-          "order": 10,
+          "order": 11,
           "markdownDescription": "# Trace Type Thresholds\n\nTrigger diagnostics from trace files when the number of types created locally in this check call exceeds these thresholds.\n\n* -1 will disable diagnostics of that severity\n"
         },
         "tsperf.tracer.traceTotalTypeThresholds": {
@@ -181,14 +187,14 @@
             "error": -1
           },
           "description": "todo",
-          "order": 11,
+          "order": 12,
           "markdownDescription": "# Trace Total Type Thresholds\n\nTrigger diagnostics from trace files when the number of types created in this check call stack exceeds these thresholds.\n\n* -1 will disable diagnostics of that severity\n"
         },
         "tsperf.tracer.traceDiagnosticsRelative": {
           "type": "boolean",
           "default": false,
           "description": "Use measurements relative to the average for trace diagnostics",
-          "order": 12
+          "order": 13
         },
         "tsperf.tracer.traceTimeRelativeThresholds": {
           "type": "object",
@@ -215,7 +221,7 @@
             "error": -1
           },
           "description": "todo",
-          "order": 13
+          "order": 14
         },
         "tsperf.tracer.traceTypeRelativeThresholds": {
           "type": "object",
@@ -242,7 +248,7 @@
             "error": -1
           },
           "description": "todo",
-          "order": 14
+          "order": 15
         },
         "tsperf.tracer.traceTotalTypeRelativeThresholds": {
           "type": "object",
@@ -269,7 +275,7 @@
             "error": -1
           },
           "description": "todo",
-          "order": 15
+          "order": 16
         }
       }
     },

--- a/scripts/generate-contributes.ts
+++ b/scripts/generate-contributes.ts
@@ -177,6 +177,13 @@ const orderedConfigurationProperties: Partial<Record<PropertyConfigKey, Record<s
     },
   },
   {
+    'tsperf.tracer.useGitBranchSaveName': {
+      type: 'boolean',
+      default: false,
+      description: 'Use the current Git branch or detached HEAD as the default save name',
+    },
+  },
+  {
     'tsperf.tracer.fileBrowserExecutable': {
       type: 'string',
       default: '',

--- a/src/appState.ts
+++ b/src/appState.ts
@@ -1,13 +1,15 @@
 import { mkdirSync, readdirSync, statSync } from 'node:fs'
-import { basename, dirname, join, relative } from 'node:path'
+import { basename, dirname, isAbsolute, join, relative } from 'node:path'
 import { log } from 'node:console'
 import { type Ref, type ShallowRef, type UnwrapRef, nextTick, watch as plainWatch, ref, shallowRef } from '@vue/runtime-core'
-import type * as vscode from 'vscode'
+import * as vscode from 'vscode'
 import type { TraceData } from '../shared/src/traceData'
 import { getTracePanel, isTraceViewAlive, postMessage } from './webview'
 import { getProjectName, getWorkspacePath } from './storage'
 import { setStatusBarState } from './statusBar'
 import { sendTraceDir } from './commands'
+import { getCurrentConfig } from './configuration'
+import { toGitSaveName } from './gitSaveName'
 
 export const afterWatches = nextTick
 
@@ -138,7 +140,8 @@ export async function initAppState(extensionContext: vscode.ExtensionContext) {
 
   workspacePath.value = getWorkspacePath()
   projectName.value = getProjectName()
-  saveName.value = 'default'
+  await afterWatches()
+  saveName.value = await getInitialSaveName()
 }
 
 const triggers: Partial<Record<keyof State, { handler: ((arg: any) => void | Promise<void>), remoteHandler: (arg: any) => void }>> = {}
@@ -192,4 +195,33 @@ function getProjectPath() {
   projectPath.value = join(storagePath, projectName.value)
   mkdirSync(projectPath.value, { recursive: true })
   return projectPath.value
+}
+
+async function getInitialSaveName() {
+  if (!getCurrentConfig().useGitBranchSaveName)
+    return 'default'
+
+  return await getGitSaveName(workspacePath.value) ?? 'default'
+}
+
+async function getGitSaveName(workspacePath: string) {
+  const gitExtension = vscode.extensions.getExtension('vscode.git')
+  if (!gitExtension)
+    return undefined
+
+  const git = gitExtension.isActive ? gitExtension.exports : await gitExtension.activate()
+  const gitApi = git.getAPI(1)
+  const repository = gitApi.repositories.find((repo: any) => isWorkspaceRepository(repo, workspacePath)) ?? gitApi.repositories[0]
+  const head = repository?.state?.HEAD
+
+  return toGitSaveName(head?.name ?? (head?.commit ? `detached-${String(head.commit).slice(0, 7)}` : undefined))
+}
+
+function isWorkspaceRepository(repository: any, workspacePath: string) {
+  const repoPath = repository?.rootUri?.fsPath
+  if (!repoPath)
+    return false
+
+  const rel = relative(repoPath, workspacePath)
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -20,6 +20,7 @@ const currentConfig = {
   traceTotalTypeRelativeThresholds: { info: 1, warning: -1, error: -1 },
   enableTraceMetrics: true,
   enableRealtimeMetrics: true,
+  useGitBranchSaveName: false,
   fileBrowserExecutable: '',
 } satisfies Record<ConfigKey, any>
 
@@ -66,6 +67,7 @@ const configValidate = {
   traceTotalTypeRelativeThresholds: isThresholds,
   enableTraceMetrics: isBoolean,
   enableRealtimeMetrics: isBoolean,
+  useGitBranchSaveName: isBoolean,
   fileBrowserExecutable: isString,
 } satisfies Record<ConfigKey, any>
 
@@ -88,6 +90,7 @@ const configHandlers = {
   traceTotalTypeRelativeThresholds: noop,
   enableTraceMetrics: noop,
   enableRealtimeMetrics: noop,
+  useGitBranchSaveName: noop,
   fileBrowserExecutable: noop,
 } satisfies Record<ConfigKey, any>
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,7 @@ export const configKeys = [
   'traceTotalTypeRelativeThresholds',
   'enableTraceMetrics',
   'enableRealtimeMetrics',
+  'useGitBranchSaveName',
   'fileBrowserExecutable',
 ] as const
 

--- a/src/gitSaveName.ts
+++ b/src/gitSaveName.ts
@@ -1,0 +1,9 @@
+export function toGitSaveName(label: string | undefined): string | undefined {
+  const normalized = label
+    ?.trim()
+    .replace(/[\\/:*?"<>|]+/g, '-')
+    .replace(/\s+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return normalized || undefined
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,22 @@
 import { describe, expect, it } from 'vitest'
+import { toGitSaveName } from '../src/gitSaveName'
 
 describe('should', () => {
   it('exported', () => {
     expect(1).toEqual(1)
+  })
+})
+
+describe('toGitSaveName', () => {
+  it('keeps simple branch names', () => {
+    expect(toGitSaveName('main')).toBe('main')
+  })
+
+  it('normalizes branch labels into safe save names', () => {
+    expect(toGitSaveName(' feature/git branch:save ')).toBe('feature-git-branch-save')
+  })
+
+  it('ignores empty labels', () => {
+    expect(toGitSaveName(' / ')).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

- Add an opt-in `tsperf.tracer.useGitBranchSaveName` setting.
- When enabled, initialize the trace save name from the active VS Code Git repository's current branch or detached HEAD.
- Sanitize Git labels before using them as storage directory names.
- Fall back to the existing `default` save when Git is unavailable or has no HEAD label.

## Why

Closes #20.

Using the current Git branch as the default save name keeps trace files and trace diagnostics aligned with the checked-out code, especially when switching between branches during performance investigations.

## Validation

- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm exec vitest run`
- `corepack pnpm run generate:contributes`
- `cd srcDev && corepack pnpm exec rollup -c`
- `corepack pnpm exec nuxt build ui`
- `corepack pnpm exec rollup -c`

