### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,6 +13,7 @@ import { addTraceFile, getWorkspacePath, openTerminal, openTraceDirectoryExterna
 import { addTraceDiagnostics, clearTaceDiagnostics } from './traceDiagnostics'
 import { setStatusBarState } from './statusBar'
 import { afterWatches, projectPath, saveName, state, traceFiles, traceRunning } from './appState'
+import { buildTraceShellCommand } from './shellCommand'
 
 const readdir = promisify(readdirC)
 
@@ -128,9 +129,7 @@ async function runTrace(args?: unknown[]) {
       return
     }
 
-    const quotedTraceDir = `'${traceDir}'`
-    // eslint-disable-next-line no-template-curly-in-string
-    const fullCmd = `(cd '${newDirName ?? workspacePath}'; ${traceCmd.replace('${traceDir}', quotedTraceDir)})`
+    const fullCmd = buildTraceShellCommand(newDirName ?? workspacePath, traceCmd, traceDir)
 
     log(fullCmd)
 

--- a/src/shellCommand.ts
+++ b/src/shellCommand.ts
@@ -1,0 +1,30 @@
+import * as process from 'node:process'
+
+type Platform = NodeJS.Platform
+const traceDirToken = '$' + '{traceDir}'
+
+function quotePosixShellArg(value: string) {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function quoteWindowsShellArg(value: string) {
+  return `"${value.replace(/"/g, '""')}"`
+}
+
+export function quoteShellArg(value: string, platform: Platform = process.platform) {
+  return platform === 'win32' ? quoteWindowsShellArg(value) : quotePosixShellArg(value)
+}
+
+export function buildTraceShellCommand(
+  cwd: string,
+  traceCmd: string,
+  traceDir: string,
+  platform: Platform = process.platform,
+) {
+  const command = traceCmd.replace(traceDirToken, quoteShellArg(traceDir, platform))
+
+  if (platform === 'win32')
+    return `(cd /d ${quoteShellArg(cwd, platform)} && ${command})`
+
+  return `(cd ${quoteShellArg(cwd, platform)} && ${command})`
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,25 @@
 import { describe, expect, it } from 'vitest'
+import { buildTraceShellCommand, quoteShellArg } from '../src/shellCommand'
 
 describe('should', () => {
   it('exported', () => {
     expect(1).toEqual(1)
+  })
+})
+
+describe('shell command generation', () => {
+  it('uses cd /d and Windows quoting when running a trace on Windows', () => {
+    const command = buildTraceShellCommand(
+      'p:\\_godot\\godot-vscode-plugin',
+      'npx tsc --noEmit --generateTrace $' + '{traceDir}',
+      'c:\\Users\\daelon\\AppData\\Roaming\\Code\\User\\globalStorage\\tsperf.tracer\\godot-tools\\default\\traces',
+      'win32',
+    )
+
+    expect(command).toBe('(cd /d "p:\\_godot\\godot-vscode-plugin" && npx tsc --noEmit --generateTrace "c:\\Users\\daelon\\AppData\\Roaming\\Code\\User\\globalStorage\\tsperf.tracer\\godot-tools\\default\\traces")')
+  })
+
+  it('keeps POSIX paths single quoted and safely escapes apostrophes', () => {
+    expect(quoteShellArg('/tmp/project with spaces/owner\'s')).toBe('\'/tmp/project with spaces/owner\'\\\'\'s\'')
   })
 })


### PR DESCRIPTION
## Summary

Fixes #48 by building the trace shell command differently on Windows:

- use `cd /d` so `cmd.exe` can switch to workspaces on another drive
- double-quote Windows paths instead of using POSIX single quotes
- keep POSIX shell quoting for non-Windows platforms
- move command construction into a small tested helper

## Verification

- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm exec vitest run`
- `corepack pnpm run generate:contributes`
- `cd srcDev && corepack pnpm exec rollup -c`
- `corepack pnpm exec nuxt build ui`
- `corepack pnpm exec rollup -c`

Notes: Nuxt/Browserslist deprecation warnings and existing Rollup circular-dependency warnings are unchanged.
