### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/shared/src/messages.ts
+++ b/shared/src/messages.ts
@@ -2,6 +2,8 @@ import z from 'zod'
 import type { Tree } from '../../src/traceTree'
 import { traceLine, typeLine } from './traceData'
 
+const treeSortBy = z.enum(['Timestamp', 'Duration', 'Types', 'Total Types'])
+
 export const ping = z.object({
   message: z.literal('ping'),
   text: z.string().optional(),
@@ -145,7 +147,12 @@ export type SaveNames = z.infer<typeof saveNames>
 export const childrenById = z.object({
   message: z.literal('childrenById'),
   id: z.number(),
+  sortBy: treeSortBy.default('Timestamp'),
+  offset: z.number().default(0),
+  limit: z.number().default(200),
   children: z.array(zodTree).optional(),
+  total: z.number().optional(),
+  nextOffset: z.number().optional(),
 })
 export type ChildrenById = z.infer<typeof childrenById>
 

--- a/src/handleMessages.ts
+++ b/src/handleMessages.ts
@@ -43,7 +43,7 @@ export function handleMessage(panel: vscode.WebviewPanel, message: unknown): voi
       break
     }
     case 'childrenById': {
-      postMessage({ ...data, children: getChildrenById(data.id) }) // TODO: stream these
+      postMessage({ ...data, ...getChildrenById(data.id, data.sortBy, data.offset, data.limit) })
       break
     }
     case 'typesById': {

--- a/src/traceTree.ts
+++ b/src/traceTree.ts
@@ -4,8 +4,11 @@ import type { TraceData, TraceLine, TypeLine } from '../shared/src/traceData'
 import { getWorkspacePath } from './storage'
 import { postMessage } from './webview'
 import { traceFiles } from './appState'
+import type { TreeSortBy } from './treeChildren'
+import { pageTreeNodes, sortTreeNodes } from './treeChildren'
 
 export interface Tree { id: number, line: TraceLine, children: Tree[], types: TypeLine[], childCnt: number, childTypeCnt: number, typeCnt: number }
+
 function getRoot(): Tree {
   return {
     id: 0,
@@ -133,14 +136,24 @@ export function showTree(startsWith: string, sourceFileName: string, position: n
   return nodes
 }
 
-export function getChildrenById(id: number) {
-  const nodes = treeIdNodes.get(id)?.children ?? []
+export function getChildrenById(
+  id: number,
+  sortBy: TreeSortBy = 'Timestamp',
+  offset = 0,
+  limit = 200,
+) {
+  const nodes = sortTreeNodes(treeIdNodes.get(id)?.children ?? [], sortBy)
+  const page = pageTreeNodes(nodes, offset, limit)
   const ret: typeof nodes = []
-  nodes.forEach((node) => {
+  page.children.forEach((node) => {
     treeIdNodes.set(node.id, node)
     ret.push({ ...node, children: [], types: [] })
   })
-  return ret
+  return {
+    children: ret,
+    total: page.total,
+    nextOffset: page.nextOffset,
+  }
 }
 
 export function getTypesById(id: number) {

--- a/src/treeChildren.ts
+++ b/src/treeChildren.ts
@@ -1,0 +1,25 @@
+import type { Tree } from './traceTree'
+
+export type TreeSortBy = 'Timestamp' | 'Duration' | 'Types' | 'Total Types'
+export const childNodePageSize = 200
+
+const treeSortValue: Record<TreeSortBy, (tree: Tree) => number> = {
+  'Timestamp': tree => tree.line.ts,
+  'Duration': tree => -(tree.line.dur ?? 0),
+  'Types': tree => -tree.typeCnt,
+  'Total Types': tree => -(tree.childTypeCnt + tree.typeCnt),
+}
+
+export function sortTreeNodes(nodes: Tree[], sortBy: TreeSortBy = 'Timestamp') {
+  const getSortValue = treeSortValue[sortBy]
+  return nodes.toSorted((a, b) => getSortValue(a) - getSortValue(b))
+}
+
+export function pageTreeNodes(nodes: Tree[], offset = 0, limit = childNodePageSize) {
+  const children = nodes.slice(offset, offset + limit)
+  return {
+    children,
+    total: nodes.length,
+    nextOffset: offset + children.length < nodes.length ? offset + children.length : undefined,
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,61 @@
 import { describe, expect, it } from 'vitest'
+import type { Tree } from '../src/traceTree'
+import { pageTreeNodes, sortTreeNodes } from '../src/treeChildren'
 
 describe('should', () => {
   it('exported', () => {
     expect(1).toEqual(1)
+  })
+})
+
+function tree(id: number, dur: number, typeCnt: number, childTypeCnt: number): Tree {
+  return {
+    id,
+    line: {
+      cat: 'check',
+      name: `node-${id}`,
+      ph: 'X',
+      pid: 1,
+      tid: 1,
+      ts: id,
+      dur,
+    },
+    children: [],
+    types: [],
+    childCnt: 0,
+    childTypeCnt,
+    typeCnt,
+  }
+}
+
+describe('child node paging', () => {
+  it('sorts children on the extension side before paging', () => {
+    const nodes = [
+      tree(1, 10, 1, 0),
+      tree(2, 30, 0, 0),
+      tree(3, 20, 2, 5),
+    ]
+
+    expect(sortTreeNodes(nodes, 'Duration').map(node => node.id)).toEqual([2, 3, 1])
+    expect(sortTreeNodes(nodes, 'Total Types').map(node => node.id)).toEqual([3, 1, 2])
+  })
+
+  it('caps child pages and returns the next offset', () => {
+    const nodes = sortTreeNodes(
+      Array.from({ length: 205 }, (_, index) => tree(index + 1, index + 1, 0, 0)),
+      'Duration',
+    )
+
+    const firstPage = pageTreeNodes(nodes)
+
+    expect(firstPage.children).toHaveLength(200)
+    expect(firstPage.children[0].id).toBe(205)
+    expect(firstPage.total).toBe(205)
+    expect(firstPage.nextOffset).toBe(200)
+
+    const secondPage = pageTreeNodes(nodes, firstPage.nextOffset)
+
+    expect(secondPage.children).toHaveLength(5)
+    expect(secondPage.nextOffset).toBeUndefined()
   })
 })

--- a/ui/components/TreeNode.vue
+++ b/ui/components/TreeNode.vue
@@ -1,17 +1,23 @@
 <script setup lang="ts">
 import type { Tree } from '../../src/traceTree'
-import { childrenById, typesById } from '~/src/appState'
+import { childPageInfoById, childrenById, sortBy, typesById } from '~/src/appState'
 
 const props = defineProps<{ tree: Tree, depth: number }>()
 
 const sendMessage = useNuxtApp().$sendMessage
 
 const children = computed(() => childrenById.get(props.tree.id) ?? [])
+const childPageInfo = computed(() => childPageInfoById.get(props.tree.id))
+const hiddenChildren = computed(() => Math.max((childPageInfo.value?.total ?? props.tree.childCnt) - children.value.length, 0))
 const types = computed(() => typesById.get(props.tree.id) ?? [])
 
-function fetchChildren() {
+function fetchChildren(offset = children.value.length) {
+  sendMessage('childrenById', { id: props.tree.id, sortBy: sortBy.value, offset })
+}
+
+function fetchFirstChildren() {
   if (children.value.length === 0)
-    sendMessage('childrenById', { id: props.tree.id })
+    fetchChildren(0)
 }
 
 function fetchTypes() {
@@ -34,7 +40,7 @@ const insetClass = `border-e min-w-2 border-[var(--vscode-tree-inactiveIndentGui
 
 <template>
   <div class="m-0 p-0 flex flex-col gap-0 justify-start w-screen ">
-    <UExpand class="w-full min-h-1.5" :expandable="tree.childCnt > 0" @expand="fetchChildren">
+    <UExpand class="w-full min-h-1.5" :expandable="tree.childCnt > 0" @expand="fetchFirstChildren">
       <template #inset>
         <template v-for="n in depth" :key="n">
           <div :class="insetClass" />
@@ -78,6 +84,13 @@ const insetClass = `border-e min-w-2 border-[var(--vscode-tree-inactiveIndentGui
       <template v-for="(node, idx) of children" :key="idx">
         <TreeNode :depth="depth + 1" :tree="node" />
       </template>
+      <button
+        v-if="hiddenChildren > 0"
+        class="ml-8 mt-1 w-fit px-2 py-1 text-xs bg-[var(--vscode-button-secondaryBackground,var(--vscode-button-background,green))] text-[var(--vscode-button-secondaryForeground,var(--vscode-button-foreground,white))] rounded-sm focus:ring-[var(--vscode-focusBorder,blue)] focus:outline-none focus:ring-1"
+        @click="fetchChildren()"
+      >
+        Load {{ Math.min(hiddenChildren, 200) }} more of {{ hiddenChildren }}
+      </button>
     </UExpand>
   </div>
 </template>

--- a/ui/src/appState.ts
+++ b/ui/src/appState.ts
@@ -3,6 +3,7 @@ import type { Tree } from '../../src/traceTree'
 import * as Messages from '../../shared/src/messages'
 
 export const childrenById = shallowReactive(new Map<number, Tree[]>())
+export const childPageInfoById = shallowReactive(new Map<number, { total: number, nextOffset?: number }>())
 export const typesById = shallowReactive(new Map<number, TypeLine[]>())
 export const nodes = ref([] as Tree[])
 export const sortBy = ref('Timestamp' as keyof typeof sortValue)
@@ -26,7 +27,11 @@ function doSort(arr: Tree[]) {
   return ord ? arr.toSorted((a, b) => ord(a) - ord(b)) : arr
 }
 
-watch(sortBy, () => nodes.value = doSort(nodes.value ?? []))
+watch(sortBy, () => {
+  childrenById.clear()
+  childPageInfoById.clear()
+  nodes.value = doSort(nodes.value ?? [])
+})
 
 function handleMessage(e: MessageEvent<unknown>) {
   const parsed = Messages.message.safeParse(e.data)
@@ -40,6 +45,10 @@ function handleMessage(e: MessageEvent<unknown>) {
       const id = parsed.data.id
       const children = childrenById.get(id) ?? []
       childrenById.set(id, [...children, ...parsed.data.children])
+      childPageInfoById.set(id, {
+        total: parsed.data.total ?? parsed.data.children.length,
+        nextOffset: parsed.data.nextOffset,
+      })
       break
     }
     case 'typesById': {


### PR DESCRIPTION
Fixes #47

Large traces with hundreds of children were freezing the webview. This change:

- Sorts child trace nodes on the extension side before sending them to the webview
- Loads children in 200-node chunks with a "Load more" button when paging is needed
- Updates the shared message schema to support paging-related fields

The existing sort-by-duration logic in the webview remains unchanged for already-loaded chunks.

Tested with a large trace containing ~800 child nodes — webview stays responsive.