### PR TITLE
Paginate child node loading to avoid UI lag

### DIFF
--- a/shared/src/messages.ts
+++ b/shared/src/messages.ts
@@ -145,7 +145,10 @@ export type SaveNames = z.infer<typeof saveNames>
 export const childrenById = z.object({
   message: z.literal('childrenById'),
   id: z.number(),
+  offset: z.number().int().min(0).default(0),
+  limit: z.number().int().positive().optional(),
   children: z.array(zodTree).optional(),
+  hasMore: z.boolean().optional(),
 })
 export type ChildrenById = z.infer<typeof childrenById>
 

--- a/src/childPaging.ts
+++ b/src/childPaging.ts
@@ -1,0 +1,13 @@
+export function pageItems<T>(items: readonly T[], offset = 0, limit = 100) {
+  const safeOffset = Math.max(0, offset)
+  const safeLimit = Math.max(1, limit)
+  const children = items.slice(safeOffset, safeOffset + safeLimit)
+
+  return {
+    items: children,
+    offset: safeOffset,
+    limit: safeLimit,
+    total: items.length,
+    hasMore: safeOffset + children.length < items.length,
+  }
+}

--- a/src/handleMessages.ts
+++ b/src/handleMessages.ts
@@ -43,7 +43,7 @@ export function handleMessage(panel: vscode.WebviewPanel, message: unknown): voi
       break
     }
     case 'childrenById': {
-      postMessage({ ...data, children: getChildrenById(data.id) }) // TODO: stream these
+      postMessage({ ...data, ...getChildrenById(data.id, data.offset, data.limit) })
       break
     }
     case 'typesById': {

--- a/src/traceTree.ts
+++ b/src/traceTree.ts
@@ -2,6 +2,7 @@ import { isAbsolute, join, relative } from 'node:path'
 import type { FileStat } from '../shared/src/messages'
 import type { TraceData, TraceLine, TypeLine } from '../shared/src/traceData'
 import { getWorkspacePath } from './storage'
+import { pageItems } from './childPaging'
 import { postMessage } from './webview'
 import { traceFiles } from './appState'
 
@@ -27,6 +28,7 @@ function getRoot(): Tree {
 }
 
 let treeIndexes: Tree[] = []
+const DEFAULT_CHILD_BATCH_SIZE = 100
 export function toTree(traceData: TraceData, workspacePath: string): Tree {
   const tree: Tree = { ...getRoot() }
   let endTs = Number.MAX_SAFE_INTEGER
@@ -133,14 +135,18 @@ export function showTree(startsWith: string, sourceFileName: string, position: n
   return nodes
 }
 
-export function getChildrenById(id: number) {
+export function getChildrenById(id: number, offset = 0, limit = DEFAULT_CHILD_BATCH_SIZE) {
   const nodes = treeIdNodes.get(id)?.children ?? []
-  const ret: typeof nodes = []
-  nodes.forEach((node) => {
+  const { items, ...meta } = pageItems(nodes, offset, limit)
+  const children: typeof items = []
+  items.forEach((node) => {
     treeIdNodes.set(node.id, node)
-    ret.push({ ...node, children: [], types: [] })
+    children.push({ ...node, children: [], types: [] })
   })
-  return ret
+  return {
+    children,
+    ...meta,
+  }
 }
 
 export function getTypesById(id: number) {

--- a/test/children-pagination.test.ts
+++ b/test/children-pagination.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { pageItems } from '../src/childPaging'
+
+describe('pageItems', () => {
+  it('returns a paged slice and metadata', () => {
+    const first = pageItems([1, 2, 3], 0, 2)
+    expect(first.total).toBe(3)
+    expect(first.hasMore).toBe(true)
+    expect(first.items).toEqual([1, 2])
+
+    const second = pageItems([1, 2, 3], 2, 2)
+    expect(second.total).toBe(3)
+    expect(second.hasMore).toBe(false)
+    expect(second.items).toEqual([3])
+  })
+})

--- a/ui/components/TreeNode.vue
+++ b/ui/components/TreeNode.vue
@@ -1,17 +1,25 @@
 <script setup lang="ts">
 import type { Tree } from '../../src/traceTree'
-import { childrenById, typesById } from '~/src/appState'
+import { childrenById, loadingChildrenById, typesById } from '~/src/appState'
 
 const props = defineProps<{ tree: Tree, depth: number }>()
+const CHILDREN_BATCH_SIZE = 100
 
 const sendMessage = useNuxtApp().$sendMessage
 
 const children = computed(() => childrenById.get(props.tree.id) ?? [])
 const types = computed(() => typesById.get(props.tree.id) ?? [])
+const isLoadingChildren = computed(() => loadingChildrenById.get(props.tree.id) ?? false)
+const hasMoreChildren = computed(() => children.value.length < props.tree.childCnt)
 
-function fetchChildren() {
-  if (children.value.length === 0)
-    sendMessage('childrenById', { id: props.tree.id })
+function fetchChildren(loadMore = false) {
+  if (isLoadingChildren.value)
+    return
+  if (!loadMore && children.value.length > 0)
+    return
+
+  loadingChildrenById.set(props.tree.id, true)
+  sendMessage('childrenById', { id: props.tree.id, offset: children.value.length, limit: CHILDREN_BATCH_SIZE })
 }
 
 function fetchTypes() {
@@ -75,9 +83,14 @@ const insetClass = `border-e min-w-2 border-[var(--vscode-tree-inactiveIndentGui
           </div>
         </div>
       </template>
-      <template v-for="(node, idx) of children" :key="idx">
+      <template v-for="node of children" :key="node.id">
         <TreeNode :depth="depth + 1" :tree="node" />
       </template>
+      <div v-if="hasMoreChildren" class="flex flex-row pl-1">
+        <button :disabled="isLoadingChildren" class="mt-1 mb-1 rounded-sm px-2 py-1 text-xs bg-[var(--vscode-button-background)] text-[var(--vscode-button-foreground)] disabled:opacity-60 focus:ring-[var(--vscode-focusBorder, blue)] focus:outline-none focus:ring-1" @click="fetchChildren(true)">
+          {{ isLoadingChildren ? 'Loading children…' : `Load more children (${props.tree.childCnt - children.length} left)` }}
+        </button>
+      </div>
     </UExpand>
   </div>
 </template>

--- a/ui/src/appState.ts
+++ b/ui/src/appState.ts
@@ -3,6 +3,7 @@ import type { Tree } from '../../src/traceTree'
 import * as Messages from '../../shared/src/messages'
 
 export const childrenById = shallowReactive(new Map<number, Tree[]>())
+export const loadingChildrenById = shallowReactive(new Map<number, boolean>())
 export const typesById = shallowReactive(new Map<number, TypeLine[]>())
 export const nodes = ref([] as Tree[])
 export const sortBy = ref('Timestamp' as keyof typeof sortValue)
@@ -39,7 +40,9 @@ function handleMessage(e: MessageEvent<unknown>) {
         return
       const id = parsed.data.id
       const children = childrenById.get(id) ?? []
-      childrenById.set(id, [...children, ...parsed.data.children])
+      const next = parsed.data.offset === 0 ? [...parsed.data.children] : [...children, ...parsed.data.children]
+      childrenById.set(id, next)
+      loadingChildrenById.set(id, false)
       break
     }
     case 'typesById': {
@@ -86,6 +89,9 @@ function handleMessage(e: MessageEvent<unknown>) {
       if (data.resetFileList) {
         files.value = []
         nodes.value = []
+        childrenById.clear()
+        loadingChildrenById.clear()
+        typesById.clear()
       }
       if (parsed.data.fileName && !files.value.some(x => x.fileName === data.fileName && x.dirName === data.dirName))
         files.value.push(parsed.data)


### PR DESCRIPTION
Addresses #47.

This caps child-node fetching/rendering in the webview to small batches and adds a Load more button per node so very wide subtrees don't freeze the trace UI.

Changes:
- paginate child fetches via a reusable helper
- stream child pages from the extension host
- keep a per-node loading flag to avoid duplicate requests
- clear child caches on trace reset
- add a unit test for the paging helper

Verified with:
- pnpm vitest run test/index.test.ts test/children-pagination.test.ts
- pnpm typecheck
- pnpm exec eslint ...
- pnpm build