### PR TITLE
Warn before tracing incremental builds

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -9,10 +9,12 @@ import { getTracePanel, prepareWebView } from './webview'
 import { getCurrentConfig } from './configuration'
 import { log } from './logger'
 import type { CommandId } from './constants'
+import { getParsedCommandLine } from './shared'
 import { addTraceFile, getWorkspacePath, openTerminal, openTraceDirectoryExternal, setLastMessageTrigger } from './storage'
 import { addTraceDiagnostics, clearTaceDiagnostics } from './traceDiagnostics'
 import { setStatusBarState } from './statusBar'
 import { afterWatches, projectPath, saveName, state, traceFiles, traceRunning } from './appState'
+import { getIncrementalTraceWarning } from './incrementalBuild'
 
 const readdir = promisify(readdirC)
 
@@ -121,7 +123,7 @@ async function runTrace(args?: unknown[]) {
 
   const newDirName = dirName
   // TODO: use logic from real time metrics that get the tsconfig path
-  afterWatches(() => {
+  afterWatches(async () => {
     const traceDir = state.tracePath.value
     if (!traceDir) {
       vscode.window.showWarningMessage('No workspace or folder open')
@@ -138,6 +140,16 @@ async function runTrace(args?: unknown[]) {
     if (!newProjectPath) {
       vscode.window.showErrorMessage('could not get project path from workspace folders')
       return
+    }
+
+    try {
+      const parsedCommandLine = await getParsedCommandLine(newDirName ?? workspacePath)
+      const warning = getIncrementalTraceWarning(parsedCommandLine.options)
+      if (warning)
+        vscode.window.showWarningMessage(warning)
+    }
+    catch (e) {
+      log(`could not check incremental build settings: ${e}`)
     }
 
     traceRunning.value = true

--- a/src/incrementalBuild.ts
+++ b/src/incrementalBuild.ts
@@ -1,0 +1,11 @@
+import type { CompilerOptions } from 'typescript'
+
+export function getIncrementalTraceWarning(options: Pick<CompilerOptions, 'composite' | 'incremental' | 'tsBuildInfoFile'>) {
+  if (!options.incremental && !options.composite)
+    return undefined
+
+  const enabledBy = options.incremental ? 'incremental' : 'composite'
+  const buildInfo = options.tsBuildInfoFile ? ` (${options.tsBuildInfoFile})` : ''
+
+  return `Tracing with ${enabledBy} builds enabled may reuse .tsbuildinfo${buildInfo} and produce traces that do not represent a clean type-check. Consider disabling incremental builds or deleting the build info file before comparing traces.`
+}

--- a/test/incremental-build.test.ts
+++ b/test/incremental-build.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { getIncrementalTraceWarning } from '../src/incrementalBuild'
+
+describe('getIncrementalTraceWarning', () => {
+  it('does not warn when incremental options are disabled', () => {
+    expect(getIncrementalTraceWarning({})).toBeUndefined()
+    expect(getIncrementalTraceWarning({ incremental: false, composite: false })).toBeUndefined()
+  })
+
+  it('warns when incremental builds are enabled', () => {
+    const warning = getIncrementalTraceWarning({
+      incremental: true,
+      tsBuildInfoFile: '.cache/project.tsbuildinfo',
+    })
+
+    expect(warning).toContain('incremental')
+    expect(warning).toContain('.cache/project.tsbuildinfo')
+  })
+
+  it('warns when composite builds imply incremental behavior', () => {
+    const warning = getIncrementalTraceWarning({ composite: true })
+
+    expect(warning).toContain('composite')
+    expect(warning).toContain('.tsbuildinfo')
+  })
+})


### PR DESCRIPTION
Fixes #21

- inspect the selected tsconfig before running a trace
- warn when incremental or composite builds are enabled
- mention the configured tsBuildInfoFile when available
- keep trace execution working even if the config check fails
- add focused coverage for the warning helper

Validation:
- pnpm vitest run test/incremental-build.test.ts
- pnpm typecheck
- pnpm exec eslint .
- pnpm build