### PR TITLE
Fix tsconfig node_modules glob

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -6,9 +6,10 @@ import * as vscode from 'vscode'
 import type { FormatDiagnosticsHost } from 'typescript'
 
 import { log } from './logger'
+import { tsconfigExcludeGlob, tsconfigIncludeGlob } from './tsconfigSearch'
 
 export async function getTsconfigFile(path: string) {
-  let files = await vscode.workspace.findFiles('**/tsconfig.json', '**​/node_modules/**')
+  let files = await vscode.workspace.findFiles(tsconfigIncludeGlob, tsconfigExcludeGlob)
   files = files.sort((a, b) => b.fsPath.length - a.fsPath.length)
     .filter(p => !p.fsPath.includes('node_modules'))
 

--- a/src/tsconfigSearch.ts
+++ b/src/tsconfigSearch.ts
@@ -1,0 +1,2 @@
+export const tsconfigIncludeGlob = '**/tsconfig.json'
+export const tsconfigExcludeGlob = '**/node_modules/**'

--- a/test/tsconfig-search.test.ts
+++ b/test/tsconfig-search.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { tsconfigExcludeGlob, tsconfigIncludeGlob } from '../src/tsconfigSearch'
+
+describe('tsconfigSearch', () => {
+  it('uses a clean node_modules exclude glob', () => {
+    expect(tsconfigIncludeGlob).toBe('**/tsconfig.json')
+    expect(tsconfigExcludeGlob).toBe('**/node_modules/**')
+    expect(tsconfigExcludeGlob).not.toContain('\u200B')
+  })
+})


### PR DESCRIPTION
Fixes a hidden-character bug in tsconfig discovery.

`getTsconfigFile` was excluding `node_modules` with a glob that accidentally contained a zero-width character, so the exclusion could silently fail. This change moves the glob strings into a tiny shared helper and makes the node_modules exclusion explicit again.

The helper also gives us a small place to lock the glob values down in tests.

Validation:
- pnpm vitest run test/tsconfig-search.test.ts
- pnpm vitest run
- pnpm typecheck
- pnpm exec eslint .
- pnpm build