### PR TITLE
Fix gotoLocation message type

### DIFF
--- a/shared/src/messages.ts
+++ b/shared/src/messages.ts
@@ -26,7 +26,7 @@ export const gotoLocation = z.object({
   line: z.number(),
   character: z.number(),
 })
-export type GotoLocation = z.infer<typeof gotoPosition>
+export type GotoLocation = z.infer<typeof gotoLocation>
 
 export const deleteTraceFile = z.object({
   message: z.literal('deletTraceFile'),

--- a/test/goto-location-type.test.ts
+++ b/test/goto-location-type.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import type { GotoLocation } from '../shared/src/messages'
+
+describe('gotoLocation message type', () => {
+  it('matches the gotoLocation schema shape', () => {
+    const message: GotoLocation = {
+      character: 3,
+      fileName: 'src/index.ts',
+      line: 12,
+      message: 'gotoLocation',
+    }
+
+    expect(message.message).toBe('gotoLocation')
+    expect(message.fileName).toBe('src/index.ts')
+  })
+})


### PR DESCRIPTION
Fixes a small shared message type mismatch.

`GotoLocation` was inferred from `gotoPosition`, so the exported TypeScript type had `pos` instead of the `line` and `character` fields that the `gotoLocation` schema accepts. This points the type alias at the matching schema and adds a small regression test around the message shape.

Validation:
- pnpm vitest run test/goto-location-type.test.ts
- pnpm vitest run
- pnpm typecheck
- pnpm exec eslint .
- pnpm build