### PR TITLE
Accept corrected position type counts message

### DIFF
--- a/shared/src/messages.ts
+++ b/shared/src/messages.ts
@@ -51,7 +51,7 @@ export const gotoTracePosition = z.object({
 export type GotoTracePosition = z.infer<typeof gotoTracePosition>
 
 export const positionTypeCounts = z.object({
-  message: z.literal('postionTypeCounts'),
+  message: z.literal('positionTypeCounts').or(z.literal('postionTypeCounts')),
   counts: z.record(z.string(), z.record(z.string(), z.number())),
 })
 export type PositionTypeCounts = z.infer<typeof positionTypeCounts>

--- a/test/position-type-counts-message.test.ts
+++ b/test/position-type-counts-message.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { message } from '../shared/src/messages'
+
+describe('positionTypeCounts message', () => {
+  it('accepts the correctly spelled message name', () => {
+    const parsed = message.safeParse({
+      counts: { 1: { 2: 3 } },
+      message: 'positionTypeCounts',
+    })
+
+    expect(parsed.success).toBe(true)
+  })
+
+  it('keeps accepting the legacy misspelled message name', () => {
+    const parsed = message.safeParse({
+      counts: { 1: { 2: 3 } },
+      message: 'postionTypeCounts',
+    })
+
+    expect(parsed.success).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes a small typo in the shared message schema.

The `positionTypeCounts` schema currently accepts the misspelled message name `postionTypeCounts`. This adds the correctly spelled `positionTypeCounts` name while still accepting the legacy spelling, so existing callers do not break.

Validation:
- pnpm vitest run test/position-type-counts-message.test.ts
- pnpm vitest run
- pnpm typecheck
- pnpm exec eslint .
- pnpm build