### PR TITLE
Accept corrected delete trace file message

### DIFF
--- a/shared/src/messages.ts
+++ b/shared/src/messages.ts
@@ -29,7 +29,7 @@ export const gotoLocation = z.object({
 export type GotoLocation = z.infer<typeof gotoPosition>
 
 export const deleteTraceFile = z.object({
-  message: z.literal('deletTraceFile'),
+  message: z.literal('deleteTraceFile').or(z.literal('deletTraceFile')),
   fileName: z.string(),
   dirName: z.string(),
 })

--- a/src/handleMessages.ts
+++ b/src/handleMessages.ts
@@ -51,6 +51,7 @@ export function handleMessage(panel: vscode.WebviewPanel, message: unknown): voi
       break
     }
 
+    case 'deleteTraceFile':
     case 'deletTraceFile': {
       deleteTraceFiles(data.fileName, data.dirName)
     }

--- a/test/delete-trace-file-message.test.ts
+++ b/test/delete-trace-file-message.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { message } from '../shared/src/messages'
+
+describe('deleteTraceFile message', () => {
+  it('accepts the corrected message name', () => {
+    const parsed = message.safeParse({
+      dirName: 'traces',
+      fileName: 'trace.json',
+      message: 'deleteTraceFile',
+    })
+
+    expect(parsed.success).toBe(true)
+  })
+
+  it('keeps accepting the legacy misspelled message name', () => {
+    const parsed = message.safeParse({
+      dirName: 'traces',
+      fileName: 'trace.json',
+      message: 'deletTraceFile',
+    })
+
+    expect(parsed.success).toBe(true)
+  })
+})

--- a/ui/components/fileManager.client.vue
+++ b/ui/components/fileManager.client.vue
@@ -4,7 +4,7 @@ import { files, traceRunning } from '../src/appState'
 const sendMessage = useNuxtApp().$sendMessage
 
 function deleteTraceFile(fileName: string, dirName: string) {
-  sendMessage('deletTraceFile', { fileName, dirName })
+  sendMessage('deleteTraceFile', { fileName, dirName })
   const newFiles = files.value.filter(x => !(x.dirName === dirName && x.fileName === fileName))
   files.value = newFiles
 }


### PR DESCRIPTION
Fixes a small message-name typo without breaking old callers.

The file manager now sends `deleteTraceFile`, and the shared schema/extension handler accept both the corrected name and the legacy `deletTraceFile` spelling. That keeps existing messages working while letting new code use the spelled-out name.

Validation:
- pnpm vitest run test/delete-trace-file-message.test.ts
- pnpm vitest run
- pnpm typecheck
- pnpm exec eslint .
- pnpm build