### PR TITLE
Fix restart tsserver description typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "tsperf.tracer.restartTsserverOnIteration": {
           "type": "boolean",
           "default": false,
-          "description": "Restart tsserver on each iteration to avoid caching influincing measurements",
+          "description": "Restart tsserver on each iteration to avoid caching influencing measurements",
           "order": 4
         },
         "tsperf.tracer.allIdentifiers": {

--- a/scripts/generate-contributes.ts
+++ b/scripts/generate-contributes.ts
@@ -152,7 +152,7 @@ const orderedConfigurationProperties: Partial<Record<PropertyConfigKey, Record<s
     'tsperf.tracer.restartTsserverOnIteration': {
       type: 'boolean',
       default: false,
-      description: 'Restart tsserver on each iteration to avoid caching influincing measurements',
+      description: 'Restart tsserver on each iteration to avoid caching influencing measurements',
     },
   },
   {


### PR DESCRIPTION
Fixes a typo in the user-facing `restartTsserverOnIteration` setting description.

The generated package contribution text said `influincing`; this updates the source generator and regenerated `package.json` so the VS Code setting description reads correctly.

Validation:
- pnpm generate:contributes
- pnpm vitest run
- pnpm typecheck
- pnpm exec eslint .
- pnpm build