### PR TITLE
Allow trace goto at position zero

### DIFF
--- a/test/trace-position.test.ts
+++ b/test/trace-position.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { hasTracePosition } from '../ui/src/tracePosition'
+
+describe('hasTracePosition', () => {
+  it('accepts zero as a valid trace position', () => {
+    expect(hasTracePosition('src/index.ts', 0)).toBe(true)
+  })
+
+  it('rejects missing paths and positions', () => {
+    expect(hasTracePosition(undefined, 0)).toBe(false)
+    expect(hasTracePosition('src/index.ts', undefined)).toBe(false)
+  })
+})

--- a/ui/components/TreeNode.vue
+++ b/ui/components/TreeNode.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Tree } from '../../src/traceTree'
 import { childrenById, typesById } from '~/src/appState'
+import { hasTracePosition } from '~/src/tracePosition'
 
 const props = defineProps<{ tree: Tree, depth: number }>()
 
@@ -22,7 +23,7 @@ function fetchTypes() {
 function gotoPosition() {
   if ('name' in props.tree.line) {
     const { path, pos } = props.tree.line.args ?? { path: undefined, pos: undefined }
-    if (!path || !pos)
+    if (!hasTracePosition(path, pos))
       return
 
     sendMessage('gotoPosition', { fileName: path, pos })

--- a/ui/src/tracePosition.ts
+++ b/ui/src/tracePosition.ts
@@ -1,0 +1,3 @@
+export function hasTracePosition(path: string | undefined, pos: number | undefined): path is string {
+  return Boolean(path) && pos !== undefined
+}


### PR DESCRIPTION
Fixes a small trace navigation edge case.

`TreeNode` showed the goto button whenever a trace line had a position, including `pos: 0`, but the click handler used a truthy check and returned early for zero. This changes the guard to check only for `undefined`, so the start of a file remains navigable.

Validation:
- pnpm vitest run test/trace-position.test.ts
- pnpm vitest run
- pnpm typecheck
- pnpm exec eslint .
- pnpm build