### PR TITLE
Fix trace tree root duration

### DIFF
--- a/src/traceDuration.ts
+++ b/src/traceDuration.ts
@@ -1,0 +1,6 @@
+export function getTraceRootDuration(currentDuration: number, line: { ts: number, dur?: number }): number {
+  if (line.dur === Number.MAX_SAFE_INTEGER)
+    return currentDuration
+
+  return Math.max(currentDuration, line.ts + (line.dur ?? 0))
+}

--- a/src/traceTree.ts
+++ b/src/traceTree.ts
@@ -4,6 +4,7 @@ import type { TraceData, TraceLine, TypeLine } from '../shared/src/traceData'
 import { getWorkspacePath } from './storage'
 import { postMessage } from './webview'
 import { traceFiles } from './appState'
+import { getTraceRootDuration } from './traceDuration'
 
 export interface Tree { id: number, line: TraceLine, children: Tree[], types: TypeLine[], childCnt: number, childTypeCnt: number, typeCnt: number }
 function getRoot(): Tree {
@@ -31,7 +32,7 @@ export function toTree(traceData: TraceData, workspacePath: string): Tree {
   const tree: Tree = { ...getRoot() }
   let endTs = Number.MAX_SAFE_INTEGER
   let curr = tree
-  let maxDur = 0
+  let maxEndTs = 0
   let id = 0
 
   const stack: Tree[] = []
@@ -44,8 +45,7 @@ export function toTree(traceData: TraceData, workspacePath: string): Tree {
     if ('args' in line && line.args?.path && isAbsolute(line.args?.path))
       line.args.path = relative(workspacePath, line.args.path)
 
-    if (line.dur !== Number.MAX_SAFE_INTEGER && (line.dur ?? 0) > maxDur)
-      maxDur = line.ts
+    maxEndTs = getTraceRootDuration(maxEndTs, line)
 
     while (line.ts > endTs) {
       if (stack.length === 0)
@@ -70,7 +70,7 @@ export function toTree(traceData: TraceData, workspacePath: string): Tree {
     }
   }
 
-  tree.line.dur = maxDur
+  tree.line.dur = maxEndTs
   return tree
 }
 

--- a/test/trace-duration.test.ts
+++ b/test/trace-duration.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { getTraceRootDuration } from '../src/traceDuration'
+
+describe('getTraceRootDuration', () => {
+  it('uses the end timestamp of a finite trace event', () => {
+    expect(getTraceRootDuration(0, { dur: 5, ts: 10 })).toBe(15)
+  })
+
+  it('keeps the current duration for open-ended root events', () => {
+    expect(getTraceRootDuration(22, { dur: Number.MAX_SAFE_INTEGER, ts: 10 })).toBe(22)
+  })
+})


### PR DESCRIPTION
Fixes the root duration computed by `toTree`.

The code compared event durations while tracking the root duration, but assigned `line.ts` when it found a larger duration. That mixes timestamp and duration units. This now tracks the latest finite event end timestamp (`ts + dur`) so the synthetic root duration covers the loaded trace range.

Validation:
- pnpm vitest run test/trace-duration.test.ts
- pnpm vitest run
- pnpm typecheck
- pnpm exec eslint .
- pnpm build