### PR TITLE
Convert tsserver request locations to one based

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { initDiagnostics } from './traceDiagnostics'
 import { initWebviewPanel } from './webview'
 import { initStatusBar } from './statusBar'
 import { initAppState } from './appState'
+import { toTsserverLocation } from './tsserverLocation'
 
 let ts: typeof import('typescript')
 let tsPath: string
@@ -168,12 +169,13 @@ async function createLanguageServiceTestMatrix(
           positionMap.set(start, benchmark)
         }
         const benchmark = positionMap.get(start)!
+        const tsserverLocation = toTsserverLocation(benchmark.line, benchmark.offset)
         inputs.push({
           commandLine,
           fileName,
           start,
-          line: benchmark.line,
-          offset: benchmark.offset,
+          line: tsserverLocation.line,
+          offset: tsserverLocation.offset,
           tsPath,
           packageDirectory,
         })

--- a/src/tsserverLocation.ts
+++ b/src/tsserverLocation.ts
@@ -1,0 +1,6 @@
+export function toTsserverLocation(line: number, offset: number): { line: number, offset: number } {
+  return {
+    line: line + 1,
+    offset: offset + 1,
+  }
+}

--- a/test/tsserver-location.test.ts
+++ b/test/tsserver-location.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { toTsserverLocation } from '../src/tsserverLocation'
+
+describe('toTsserverLocation', () => {
+  it('converts TypeScript zero-based positions to tsserver one-based positions', () => {
+    expect(toTsserverLocation(0, 0)).toEqual({ line: 1, offset: 1 })
+    expect(toTsserverLocation(4, 8)).toEqual({ line: 5, offset: 9 })
+  })
+})


### PR DESCRIPTION
Fixes the location values sent to `typescript.tsserverRequest`.

TypeScript AST locations are zero-based, but tsserver protocol `line` and `offset` values are one-based. The realtime metrics matrix still keeps zero-based line/column values for VS Code diagnostics, but converts them before sending completion/quickinfo requests to tsserver.

Validation:
- pnpm vitest run test/tsserver-location.test.ts
- pnpm vitest run
- pnpm typecheck
- pnpm exec eslint .
- pnpm build