### PR TITLE
Include mts and cts files in realtime metrics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { initDiagnostics } from './traceDiagnostics'
 import { initWebviewPanel } from './webview'
 import { initStatusBar } from './statusBar'
 import { initAppState } from './appState'
+import { getTestFileNames } from './testFiles'
 
 let ts: typeof import('typescript')
 let tsPath: string
@@ -66,13 +67,6 @@ export function deactivate() {}
 
 // Large portions of the following code have been taken from
 // https://github.com/microsoft/DefinitelyTyped-tools/blob/41ba894ba571e55fa91ef0bb0d44d6eb6d201943/packages/perf
-
-function getTestFileNames(fileNames: readonly string[]) {
-  return fileNames.filter((name) => {
-    const ext = path.extname(name)
-    return (ext === ts.Extension.Ts || ext === ts.Extension.Tsx) && !name.endsWith(ts.Extension.Dts)
-  })
-}
 
 function getIdentifiers(sourceFile: SourceFile) {
   const { allIdentifiers } = getCurrentConfig()

--- a/src/testFiles.ts
+++ b/src/testFiles.ts
@@ -1,0 +1,9 @@
+const testFileExtensions = ['.ts', '.tsx', '.mts', '.cts'] as const
+const declarationFilePattern = /\.d\.(?:cts|mts|ts)$/i
+
+export function getTestFileNames(fileNames: readonly string[]) {
+  return fileNames.filter(name =>
+    testFileExtensions.some(ext => name.endsWith(ext))
+    && !declarationFilePattern.test(name),
+  )
+}

--- a/test/test-files.test.ts
+++ b/test/test-files.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { getTestFileNames } from '../src/testFiles'
+
+describe('getTestFileNames', () => {
+  it('includes TypeScript source module extensions', () => {
+    expect(getTestFileNames([
+      'src/a.ts',
+      'src/b.tsx',
+      'src/c.mts',
+      'src/d.cts',
+    ])).toEqual([
+      'src/a.ts',
+      'src/b.tsx',
+      'src/c.mts',
+      'src/d.cts',
+    ])
+  })
+
+  it('excludes declaration files and non-TypeScript files', () => {
+    expect(getTestFileNames([
+      'src/a.d.ts',
+      'src/b.d.mts',
+      'src/c.d.cts',
+      'src/d.js',
+    ])).toEqual([])
+  })
+})


### PR DESCRIPTION
Adds `.mts` and `.cts` source files to the realtime metrics file filter.

The current filter only includes `.ts` and `.tsx`, so TypeScript projects using native ESM/CJS source extensions are skipped. Declaration files are still excluded, including `.d.ts`, `.d.mts`, and `.d.cts`.

Validation:
- pnpm vitest run test/test-files.test.ts
- pnpm vitest run
- pnpm typecheck
- pnpm exec eslint .
- pnpm build