### PR TITLE
Clamp editor trace lookup position

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,6 +13,7 @@ import { addTraceFile, getWorkspacePath, openTerminal, openTraceDirectoryExterna
 import { addTraceDiagnostics, clearTaceDiagnostics } from './traceDiagnostics'
 import { setStatusBarState } from './statusBar'
 import { afterWatches, projectPath, saveName, state, traceFiles, traceRunning } from './appState'
+import { getTracePositionFromEditorOffset } from './editorTracePosition'
 
 const readdir = promisify(readdirC)
 
@@ -94,7 +95,7 @@ function gotoTracePosition(context: vscode.ExtensionContext) {
   const relativePath = relative(workspacePth, editor.document.fileName)
 
   getTracePanel(context)?.reveal()
-  showTree('', relativePath, startOffset - (editor.document.getText()[startOffset + 1] === '\n' ? 0 : 1))
+  showTree('', relativePath, getTracePositionFromEditorOffset(editor.document.getText(), startOffset))
 }
 
 async function runTrace(args?: unknown[]) {

--- a/src/editorTracePosition.ts
+++ b/src/editorTracePosition.ts
@@ -1,0 +1,4 @@
+export function getTracePositionFromEditorOffset(text: string, startOffset: number): number {
+  const adjustment = text[startOffset + 1] === '\n' ? 0 : 1
+  return Math.max(0, startOffset - adjustment)
+}

--- a/test/editor-trace-position.test.ts
+++ b/test/editor-trace-position.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { getTracePositionFromEditorOffset } from '../src/editorTracePosition'
+
+describe('getTracePositionFromEditorOffset', () => {
+  it('clamps the first editor offset to zero', () => {
+    expect(getTracePositionFromEditorOffset('const value = 1', 0)).toBe(0)
+  })
+
+  it('keeps the current offset before a newline', () => {
+    expect(getTracePositionFromEditorOffset('a\nb', 0)).toBe(0)
+  })
+
+  it('keeps the previous-offset lookup for normal positions', () => {
+    expect(getTracePositionFromEditorOffset('const value = 1', 6)).toBe(5)
+  })
+})


### PR DESCRIPTION
Fixes an editor-to-trace navigation edge case.

`gotoTracePosition` subtracts one from the editor offset for normal cursor positions before filtering the trace tree. At the beginning of a file that produced `-1`, which makes the trace filter behave like no position was supplied. This clamps the computed trace position at zero.

Validation:
- pnpm vitest run test/editor-trace-position.test.ts
- pnpm vitest run
- pnpm typecheck
- pnpm exec eslint .
- pnpm build