### PR TITLE
Fix trace diagnostic typo names

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -10,7 +10,7 @@ import { getCurrentConfig } from './configuration'
 import { log } from './logger'
 import type { CommandId } from './constants'
 import { addTraceFile, getWorkspacePath, openTerminal, openTraceDirectoryExternal, setLastMessageTrigger } from './storage'
-import { addTraceDiagnostics, clearTaceDiagnostics } from './traceDiagnostics'
+import { addTraceDiagnostics, clearTraceDiagnostics } from './traceDiagnostics'
 import { setStatusBarState } from './statusBar'
 import { afterWatches, projectPath, saveName, state, traceFiles, traceRunning } from './appState'
 
@@ -47,7 +47,7 @@ async function sendTrace(dirName: string, fileName: string) {
     processTraceFiles().then(() => {
       showTree('check', '', 0)
 
-      clearTaceDiagnostics()
+      clearTraceDiagnostics()
       for (const editor of vscode.window.visibleTextEditors) {
         const visibleFileName = editor.document.fileName
         addTraceDiagnostics(visibleFileName, getStatsFromTree(visibleFileName))

--- a/src/traceDiagnostics.ts
+++ b/src/traceDiagnostics.ts
@@ -23,7 +23,7 @@ vscode.window.onDidChangeActiveTextEditor((event) => {
     addTraceDiagnostics(fileName, getStatsFromTree(fileName))
 })
 
-export function clearTaceDiagnostics() {
+export function clearTraceDiagnostics() {
   fileStatus.clear()
   if (diagnosticCollection)
     diagnosticCollection.clear()
@@ -52,7 +52,7 @@ export async function addTraceDiagnostics(fileName: string, stats: FileStat[]) {
 
   let averages
 
-  let toDiagnistic: typeof fileStatToDiagnostic | typeof fileStatToRelativeDiagnostic = fileStatToDiagnostic
+  let toDiagnostic: typeof fileStatToDiagnostic | typeof fileStatToRelativeDiagnostic = fileStatToDiagnostic
   if (relative) {
     const durations = stats.map(x => x.dur).filter(x => x >= averageThresholds.dur)
     const types = stats.map(x => x.types).filter(x => x >= averageThresholds.types)
@@ -62,7 +62,7 @@ export async function addTraceDiagnostics(fileName: string, stats: FileStat[]) {
       types: types.length ? types.reduce((a, b) => a + b, 0) / types.length : 0,
       totalTypes: totalTypes.length ? totalTypes.reduce((a, b) => a + b, 0) / totalTypes.length : 0,
     }
-    toDiagnistic = fileStatToRelativeDiagnostic
+    toDiagnostic = fileStatToRelativeDiagnostic
   }
 
   const diagnostics = []
@@ -72,7 +72,7 @@ export async function addTraceDiagnostics(fileName: string, stats: FileStat[]) {
     if (lastPos === stat.pos)
       continue // do not create diagnostics for further checks at the same starting position
 
-    const diagnostic = toDiagnistic(stat, document, averages!)
+    const diagnostic = toDiagnostic(stat, document, averages!)
     if (diagnostic)
       diagnostics.push(diagnostic)
 


### PR DESCRIPTION
Fixes a couple of internal typo names in trace diagnostics.

This renames `clearTaceDiagnostics` to `clearTraceDiagnostics` and `toDiagnistic` to `toDiagnostic`. There is no behavior change; this is just cleanup around names that are otherwise easy to copy forward.

Validation:
- pnpm vitest run
- pnpm typecheck
- pnpm exec eslint .
- pnpm build