### PR TITLE
Extract trace duration formatter

### DIFF
--- a/test/trace-duration-format.test.ts
+++ b/test/trace-duration-format.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { formatTraceDurationMs } from '../ui/src/traceDuration'
+
+describe('formatTraceDurationMs', () => {
+  it('formats microsecond trace durations as milliseconds', () => {
+    expect(formatTraceDurationMs(1234)).toBe('1.234ms')
+  })
+
+  it('formats missing durations as zero', () => {
+    expect(formatTraceDurationMs(undefined)).toBe('0ms')
+  })
+})

--- a/ui/components/TreeNode.vue
+++ b/ui/components/TreeNode.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Tree } from '../../src/traceTree'
 import { childrenById, typesById } from '~/src/appState'
+import { formatTraceDurationMs } from '~/src/traceDuration'
 
 const props = defineProps<{ tree: Tree, depth: number }>()
 
@@ -47,7 +48,7 @@ const insetClass = `border-e min-w-2 border-[var(--vscode-tree-inactiveIndentGui
             <span class="min-w-48">
               {{ tree.line.name }} ({{ tree.childCnt }}):
             </span><span>
-              {{ Math.round(props.tree.line.dur ?? 0 / 1000) / 1000 }}ms
+              {{ formatTraceDurationMs(props.tree.line.dur) }}
             </span>
             <div class="grow opacity-20 hover:opacity-100 h-full">
               <div class="mt-4 border-b border-dashed border-[var(--vscode-tree-indentGuidesStroke)]" />

--- a/ui/src/traceDuration.ts
+++ b/ui/src/traceDuration.ts
@@ -1,0 +1,3 @@
+export function formatTraceDurationMs(duration: number | undefined): string {
+  return `${Math.round(duration ?? 0) / 1000}ms`
+}


### PR DESCRIPTION
Moves trace duration formatting out of the TreeNode template.

The template had the milliseconds conversion inline, which made the `??` fallback and `/1000` expression easy to misread. This keeps the existing displayed value but puts the formatting in a small helper with coverage for defined and missing durations.

Validation:
- pnpm vitest run test/trace-duration-format.test.ts
- pnpm vitest run
- pnpm typecheck
- pnpm exec eslint .
- pnpm build