### PR TITLE
Respect zero trace filter positions

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -45,7 +45,7 @@ async function sendTrace(dirName: string, fileName: string) {
   stream.on('end', () => {
     addTraceFile(fileName, fileContents)
     processTraceFiles().then(() => {
-      showTree('check', '', 0)
+      showTree('check', '', '')
 
       clearTaceDiagnostics()
       for (const editor of vscode.window.visibleTextEditors) {

--- a/src/traceFilter.ts
+++ b/src/traceFilter.ts
@@ -1,0 +1,6 @@
+export function matchesTracePositionFilter(candidate: number | undefined, position: number | '') {
+  if (position === '')
+    return true
+
+  return candidate === position
+}

--- a/src/traceTree.ts
+++ b/src/traceTree.ts
@@ -4,6 +4,7 @@ import type { TraceData, TraceLine, TypeLine } from '../shared/src/traceData'
 import { getWorkspacePath } from './storage'
 import { postMessage } from './webview'
 import { traceFiles } from './appState'
+import { matchesTracePositionFilter } from './traceFilter'
 
 export interface Tree { id: number, line: TraceLine, children: Tree[], types: TypeLine[], childCnt: number, childTypeCnt: number, typeCnt: number }
 function getRoot(): Tree {
@@ -81,16 +82,13 @@ export async function processTraceFiles() {
 }
 
 export function filterTree(startsWith: string, sourceFileName: string, position: number | '', tree = traceTree): Tree[] {
-  if (position === '')
-    position = 0
-
   if (!tree)
     return []
 
   if (
     ('name' in tree.line && tree.line.name.startsWith(startsWith))
     && (!sourceFileName || ((tree.line.args?.path ?? '').endsWith(sourceFileName)))
-    && (!(position > 0) || ((tree.line.args?.pos ?? 0) === position))
+    && matchesTracePositionFilter(tree.line.args?.pos, position)
   ) {
     return [tree]
   }
@@ -174,7 +172,7 @@ export function getStatsFromTree(fileName: string) {
     node.children.forEach(visit)
   }
 
-  const fileNodes = filterTree('', relative(workspacePath, fileName), 0)
+  const fileNodes = filterTree('', relative(workspacePath, fileName), '')
   fileNodes.forEach(visit)
 
   return stats

--- a/test/trace-filter.test.ts
+++ b/test/trace-filter.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { matchesTracePositionFilter } from '../src/traceFilter'
+
+describe('matchesTracePositionFilter', () => {
+  it('treats an empty position as no filter', () => {
+    expect(matchesTracePositionFilter(undefined, '')).toBe(true)
+    expect(matchesTracePositionFilter(12, '')).toBe(true)
+    expect(matchesTracePositionFilter(0, '')).toBe(true)
+  })
+
+  it('matches numeric positions exactly, including zero', () => {
+    expect(matchesTracePositionFilter(0, 0)).toBe(true)
+    expect(matchesTracePositionFilter(12, 12)).toBe(true)
+    expect(matchesTracePositionFilter(12, 0)).toBe(false)
+    expect(matchesTracePositionFilter(undefined, 0)).toBe(false)
+  })
+})

--- a/ui/app.vue
+++ b/ui/app.vue
@@ -7,7 +7,7 @@ const sendMesage = useNuxtApp().$sendMessage
 
 const sortOptions = ['Timestamp', 'Duration', 'Types', 'Total Types'] as const
 
-const filters = useState('treeFilters', () => ({ startsWith: 'check', sourceFileName: '', position: 0 as number | '' }))
+const filters = useState('treeFilters', () => ({ startsWith: 'check', sourceFileName: '', position: '' as number | '' }))
 
 function setStartsWith(event: any) {
   filters.value.startsWith = event.target.value
@@ -18,7 +18,8 @@ function setSourceFileName(event: any) {
 }
 
 function setPosition(event: any) {
-  filters.value.position = +event.target.value
+  const value = event.target.value
+  filters.value.position = value === '' ? '' : +value
 }
 
 function handleMessage(e: MessageEvent<unknown>) {


### PR DESCRIPTION
Fixes trace position filtering when the target position is `0`.

`filterTree` used `!(position > 0)` to decide when no position filter was present. That makes numeric `0` behave like no filter, so a trace event at the start of a file cannot be selected exactly. This keeps `''` as the no-filter value and treats every number, including `0`, as an exact position filter. Call sites that wanted no filter now pass `''` explicitly.

Validation:
- pnpm vitest run test/trace-filter.test.ts
- pnpm vitest run
- pnpm typecheck
- pnpm exec eslint .
- pnpm build
